### PR TITLE
이벤트 관련 엔티티 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+
+.idea/Backend.iml
+.idea/compiler.xml
+.idea/gradle.xml
+.idea/jarRepositories.xml
+.idea/jpa-buddy.xml
+.idea/misc.xml
+.idea/modules.xml
+.idea/vcs.xml

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/aiku/aiku-common/src/main/java/common/domain/event/CommonEvent.java
+++ b/aiku/aiku-common/src/main/java/common/domain/event/CommonEvent.java
@@ -1,0 +1,27 @@
+package common.domain.event;
+
+import common.domain.BaseTime;
+import common.domain.Member;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Inheritance(strategy = InheritanceType.JOINED)
+@DiscriminatorColumn(name = "DTYPE")
+public abstract class CommonEvent extends BaseTime {
+    @Column(name = "eventId")
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @JoinColumn(name = "memberId")
+    @OneToOne(fetch = FetchType.LAZY)
+    private Member member;
+
+    @JoinColumn(name = "eventNoticeId")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private EventNotice eventNotice;
+}

--- a/aiku/aiku-common/src/main/java/common/domain/event/RecommendEvent.java
+++ b/aiku/aiku-common/src/main/java/common/domain/event/RecommendEvent.java
@@ -9,16 +9,9 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@DiscriminatorValue(value = "Recommend")
 @Entity
-public class RecommendEvent extends BaseTime {
-
-    @Column(name = "recommendEventId")
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
-
-    @JoinColumn(name = "memberId")
-    @OneToOne(fetch = FetchType.LAZY)
-    private Member member;
+public class RecommendEvent extends CommonEvent {
 
     @JoinColumn(name = "recommenderId")
     @ManyToOne(fetch = FetchType.LAZY)

--- a/aiku/aiku-common/src/main/java/common/domain/log/EventLog.java
+++ b/aiku/aiku-common/src/main/java/common/domain/log/EventLog.java
@@ -1,0 +1,22 @@
+package common.domain.log;
+
+import common.domain.value_reference.BettingValue;
+import common.domain.value_reference.EventValue;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PACKAGE)
+@DiscriminatorValue(value = "EVENT")
+@Entity
+public class EventLog extends PointLog{
+
+    @Column(name = "eventLogId")
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Embedded
+    private EventValue event;
+}

--- a/aiku/aiku-common/src/main/java/common/domain/value_reference/EventValue.java
+++ b/aiku/aiku-common/src/main/java/common/domain/value_reference/EventValue.java
@@ -1,0 +1,16 @@
+package common.domain.value_reference;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PACKAGE)
+@Embeddable
+public class EventValue {
+
+    @Column(name = "eventId")
+    private Long id;
+}


### PR DESCRIPTION
## 관련 이슈 번호

- #4 

<br />

## 작업 사항
- 이벤트를 추가, 관리하기 위한 부모 객체 CommonEvent 추가
- 기존 RecommendEvent가 CommonEvent를 상속받도록 변경
- 이벤트 로그를 추적하기 위한 EventLog 추가
<br />

## 기타 사항
- CommonEvent는 공지용으로 쓰일 EventNotice의 한 이벤트 내에서 이벤트 기록이 발생하기 때문에, 다대일 관계로 작성하였습니다.
<br />

