### PR TITLE
feat : 스케줄 등록, 수정 서비스 로직 추가

### DIFF
--- a/aiku/aiku-common/src/main/java/common/domain/Schedule.java
+++ b/aiku/aiku-common/src/main/java/common/domain/Schedule.java
@@ -36,7 +36,7 @@ public class Schedule extends BaseTime{
     private Status status;
 
     @OneToMany(mappedBy = "schedule", cascade = CascadeType.ALL)
-    private List<ScheduleMember> scheduleMember = new ArrayList<>();
+    private List<ScheduleMember> scheduleMembers = new ArrayList<>();
 
     protected Schedule(TeamValue team, String scheduleName, LocalDateTime scheduleTime, Location location) {
         this.team = team;
@@ -46,13 +46,13 @@ public class Schedule extends BaseTime{
     }
 
     //==CUD 편의 메서드==
-    public static Schedule create(Member member, Long teamId, String scheduleName, LocalDateTime scheduleTime, Location location) {
+    public static Schedule create(Member member, Long teamId, String scheduleName, LocalDateTime scheduleTime, Location location, int pointAmount) {
         //스케줄 생성
         TeamValue team = new TeamValue(teamId);
         Schedule schedule = new Schedule(team, scheduleName, scheduleTime, location);
 
         //생성자를 스케줄 멤버로 추가
-        schedule.addScheduleMember();
+        schedule.addScheduleMember(member, true, pointAmount);
         return schedule;
     }
 
@@ -63,8 +63,8 @@ public class Schedule extends BaseTime{
     }
 
     //==편의 메서드==
-    public void addScheduleMember(){
-        ScheduleMember scheduleMember = new ScheduleMember();
-//        this.scheduleMember.add();
+    public void addScheduleMember(Member member, boolean isOwner, int pointAmount) {
+        ScheduleMember scheduleMember = new ScheduleMember(member, this, isOwner, pointAmount);
+        this.scheduleMembers.add(scheduleMember);
     }
 }

--- a/aiku/aiku-common/src/main/java/common/domain/ScheduleMember.java
+++ b/aiku/aiku-common/src/main/java/common/domain/ScheduleMember.java
@@ -34,4 +34,13 @@ public class ScheduleMember extends BaseTime{
 
     @Enumerated(value = EnumType.STRING)
     private Status status;
+
+    protected ScheduleMember(Member member, Schedule schedule, boolean isOwner, int pointAmount) {
+        this.member = member;
+        this.schedule = schedule;
+        this.isOwner = isOwner;
+        this.isPaid = (pointAmount > 0) ? true : false;
+        this.pointAmount = pointAmount;
+        this.status = Status.ALIVE;
+    }
 }

--- a/aiku/aiku-common/src/main/java/common/domain/value_reference/MemberValue.java
+++ b/aiku/aiku-common/src/main/java/common/domain/value_reference/MemberValue.java
@@ -3,10 +3,12 @@ package common.domain.value_reference;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PACKAGE)
 @Embeddable
 public class MemberValue {

--- a/aiku/aiku-common/src/main/java/common/exception/BaseExceptionImpl.java
+++ b/aiku/aiku-common/src/main/java/common/exception/BaseExceptionImpl.java
@@ -1,0 +1,14 @@
+package common.exception;
+
+import common.response.status.StatusCode;
+
+public class BaseExceptionImpl extends BaseException{
+
+    public BaseExceptionImpl(StatusCode status, String errorMessage) {
+        super(status, errorMessage);
+    }
+
+    public BaseExceptionImpl(StatusCode status) {
+        super(status, "예외가 발생했습니다.");
+    }
+}

--- a/aiku/aiku-common/src/main/java/common/exception/NotEnoughPoint.java
+++ b/aiku/aiku-common/src/main/java/common/exception/NotEnoughPoint.java
@@ -1,0 +1,23 @@
+package common.exception;
+
+import common.response.status.BaseErrorCode;
+import common.response.status.StatusCode;
+
+/**
+ * 소유 포인트가 부족할 때 throw
+ * 디폴트 status는 400 BadRequest
+ */
+public class NotEnoughPoint extends BaseException{
+
+    public NotEnoughPoint(StatusCode status, String errorMessage) {
+        super(status, errorMessage);
+    }
+
+    public NotEnoughPoint(String errorMessage) {
+        super(BaseErrorCode.BAD_REQUEST, errorMessage);
+    }
+
+    public NotEnoughPoint() {
+        super(BaseErrorCode.BAD_REQUEST, "소유 포인트가 부족합니다.");
+    }
+}

--- a/aiku/aiku-common/src/main/java/common/response/status/BaseErrorCode.java
+++ b/aiku/aiku-common/src/main/java/common/response/status/BaseErrorCode.java
@@ -10,10 +10,12 @@ public enum BaseErrorCode implements StatusCode{
 
     //4XX 클라이언트 에러
     BAD_REQUEST(4000, HttpStatus.BAD_REQUEST.getReasonPhrase(), HttpStatus.BAD_REQUEST),
-    UNAUTHORIZED(4001, HttpStatus.UNAUTHORIZED.getReasonPhrase(), HttpStatus.UNAUTHORIZED),
-    FORBIDDEN(4003, HttpStatus.FORBIDDEN.getReasonPhrase(), HttpStatus.FORBIDDEN),
-    NOT_FOUND(4004, HttpStatus.NOT_FOUND.getReasonPhrase(), HttpStatus.NOT_FOUND),
-    METHOD_NOT_ALLOWED(4005, HttpStatus.METHOD_NOT_ALLOWED.getReasonPhrase(), HttpStatus.METHOD_NOT_ALLOWED),
+    UNAUTHORIZED(4010, HttpStatus.UNAUTHORIZED.getReasonPhrase(), HttpStatus.UNAUTHORIZED),
+    FORBIDDEN(4030, HttpStatus.FORBIDDEN.getReasonPhrase(), HttpStatus.FORBIDDEN),
+    NOT_FOUND(4040, HttpStatus.NOT_FOUND.getReasonPhrase(), HttpStatus.NOT_FOUND),
+    METHOD_NOT_ALLOWED(4050, HttpStatus.METHOD_NOT_ALLOWED.getReasonPhrase(), HttpStatus.METHOD_NOT_ALLOWED),
+
+    NO_VALID_SCHEDULE_TIME(4003, "유효하지 않는 스케줄 시간입니다.", HttpStatus.BAD_REQUEST),
 
     //5XX 서버 에러
     INTERNAL_SERVER_ERROR(5000, HttpStatus.INTERNAL_SERVER_ERROR.name(), HttpStatus.INTERNAL_SERVER_ERROR);

--- a/aiku/aiku-common/src/test/java/common/domain/ScheduleTest.java
+++ b/aiku/aiku-common/src/test/java/common/domain/ScheduleTest.java
@@ -1,0 +1,78 @@
+package common.domain;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ScheduleTest {
+
+    @Test
+    void createWithNoPoint() {
+        //given
+        Member member = Member.create("member1");
+        Long memberId = getRandomId();
+
+        Long teamId = getRandomId();
+
+        //when
+        Schedule schedule = Schedule.create(member, teamId, "sch1", LocalDateTime.now(),
+                new Location("loc1", 1.0, 1.0), 0);
+
+        //then
+        assertThat(schedule.getScheduleMembers().size()).isEqualTo(1);
+
+        ScheduleMember scheduleMember = schedule.getScheduleMembers().get(0);
+        assertThat(scheduleMember.getSchedule()).isEqualTo(schedule);
+        assertThat(scheduleMember.getMember()).isEqualTo(member);
+        assertThat(scheduleMember.isOwner()).isEqualTo(true);
+        assertThat(scheduleMember.isPaid()).isEqualTo(false);
+    }
+
+    @Test
+    void createWithPoint() {
+        //given
+        Member member = Member.create("member1");
+        Long teamId = getRandomId();
+
+        //when
+        Schedule schedule = Schedule.create(member, teamId, "sch1", LocalDateTime.now(),
+                new Location("loc1", 1.0, 1.0), 100);
+
+        //then
+        assertThat(schedule.getScheduleMembers().size()).isEqualTo(1);
+
+        ScheduleMember scheduleMember = schedule.getScheduleMembers().get(0);
+        assertThat(scheduleMember.getSchedule()).isEqualTo(schedule);
+        assertThat(scheduleMember.getMember()).isEqualTo(member);
+        assertThat(scheduleMember.isOwner()).isEqualTo(true);
+        assertThat(scheduleMember.isPaid()).isEqualTo(true);
+        assertThat(scheduleMember.getPointAmount()).isEqualTo(100);
+    }
+
+    @Test
+    void update() {
+        //given
+        Member member = Member.create("member1");
+        Long teamId = getRandomId();
+
+        Schedule schedule = Schedule.create(member, teamId, "sch1", LocalDateTime.now(),
+                new Location("loc1", 1.0, 1.0), 100);
+
+        //when
+        String scheduleName = "new";
+        Location location = new Location("new", 2.0, 2.0);
+        schedule.update(scheduleName, LocalDateTime.now(), location);
+
+        //then
+        assertThat(schedule.getScheduleName()).isEqualTo(scheduleName);
+        assertThat(schedule.getLocation()).isEqualTo(location);
+    }
+
+    Long getRandomId(){
+        Random random = new Random();
+        return random.nextLong();
+    }
+}

--- a/aiku/aiku-main/src/main/java/aiku_main/MainConfiguration.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/MainConfiguration.java
@@ -1,0 +1,27 @@
+package aiku_main;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+@Configuration
+public class MainConfiguration {
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(EntityManager em) {
+        return new JPAQueryFactory(em);
+    }
+
+    @Bean
+    public TaskScheduler taskScheduler(){
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(5); // 스레드 풀의 크기 설정
+        scheduler.setThreadNamePrefix("scheduled-task-"); // 스레드 이름 접두사 설정
+        scheduler.setWaitForTasksToCompleteOnShutdown(true); // 애플리케이션 종료 시 남아 있는 작업 완료 대기 여부
+        scheduler.setAwaitTerminationSeconds(30); // 종료 시 대기 시간(초)
+        return scheduler;
+    }
+}

--- a/aiku/aiku-main/src/main/java/aiku_main/SpringMainApplication.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/SpringMainApplication.java
@@ -28,9 +28,4 @@ public class SpringMainApplication {
     public void postConstruct(){
         testBean.loadBean();
     }
-
-    @Bean
-    public JPAQueryFactory jpaQueryFactory(EntityManager em) {
-        return new JPAQueryFactory(em);
-    }
 }

--- a/aiku/aiku-main/src/main/java/aiku_main/application_event/event/PointChangeEvent.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/application_event/event/PointChangeEvent.java
@@ -1,0 +1,16 @@
+package aiku_main.application_event.event;
+
+import common.domain.value_reference.MemberValue;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PointChangeEvent {
+    private MemberValue member;
+    private PointChangeType sign;
+    private int pointAmount;
+
+    private PointChangeReason reason;
+    private Long reasonId;
+}

--- a/aiku/aiku-main/src/main/java/aiku_main/application_event/event/PointChangeReason.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/application_event/event/PointChangeReason.java
@@ -1,0 +1,5 @@
+package aiku_main.application_event.event;
+
+public enum PointChangeReason {
+    SCHEDULE, BETTING, RACING, SHOP, EVENT
+}

--- a/aiku/aiku-main/src/main/java/aiku_main/application_event/event/PointChangeType.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/application_event/event/PointChangeType.java
@@ -1,0 +1,5 @@
+package aiku_main.application_event.event;
+
+public enum PointChangeType {
+    PLUS, MINUS
+}

--- a/aiku/aiku-main/src/main/java/aiku_main/application_event/publisher/PointChangeEventPublisher.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/application_event/publisher/PointChangeEventPublisher.java
@@ -1,0 +1,22 @@
+package aiku_main.application_event.publisher;
+
+import aiku_main.application_event.event.PointChangeEvent;
+import aiku_main.application_event.event.PointChangeReason;
+import aiku_main.application_event.event.PointChangeType;
+import common.domain.value_reference.MemberValue;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class PointChangeEventPublisher {
+
+    private final ApplicationEventPublisher publisher;
+
+    public void publish(Long memberId, PointChangeType changeType, int pointAmount, PointChangeReason reason, Long reasonId){
+        PointChangeEvent event = new PointChangeEvent(new MemberValue(memberId), changeType, pointAmount, reason, reasonId);
+        publisher.publishEvent(event);
+    }
+
+}

--- a/aiku/aiku-main/src/main/java/aiku_main/controller/ScheduleController.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/controller/ScheduleController.java
@@ -23,7 +23,7 @@ public class ScheduleController {
                                                    @RequestBody ScheduleAddDto scheduleDto){
         Long addId = scheduleService.addSchedule(null, scheduleDto);
 
-        return BaseResponse.getSimpleRes(updateId, BaseCode.PATCH);
+        return BaseResponse.getSimpleRes(addId, BaseCode.PATCH);
     }
 
     @PatchMapping("/{scheduleId}")

--- a/aiku/aiku-main/src/main/java/aiku_main/controller/ScheduleController.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/controller/ScheduleController.java
@@ -1,5 +1,6 @@
 package aiku_main.controller;
 
+import aiku_main.dto.ScheduleAddDto;
 import aiku_main.dto.ScheduleUpdateDto;
 import aiku_main.service.ScheduleService;
 import common.response.BaseResponse;
@@ -16,6 +17,14 @@ import org.springframework.web.bind.annotation.*;
 public class ScheduleController {
 
     private final ScheduleService scheduleService;
+
+    @PostMapping()
+    public BaseResponse<BaseResultDto> addSchedule(@PathVariable Long groupId,
+                                                   @RequestBody ScheduleAddDto scheduleDto){
+        Long addId = scheduleService.addSchedule(null, scheduleDto);
+
+        return BaseResponse.getSimpleRes(updateId, BaseCode.PATCH);
+    }
 
     @PatchMapping("/{scheduleId}")
     public BaseResponse<BaseResultDto> updateSchedule(@PathVariable Long groupId,

--- a/aiku/aiku-main/src/main/java/aiku_main/controller/ScheduleController.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/controller/ScheduleController.java
@@ -21,9 +21,9 @@ public class ScheduleController {
     @PostMapping()
     public BaseResponse<BaseResultDto> addSchedule(@PathVariable Long groupId,
                                                    @RequestBody ScheduleAddDto scheduleDto){
-        Long addId = scheduleService.addSchedule(null, scheduleDto);
+        Long addId = scheduleService.addSchedule(null, groupId, scheduleDto);
 
-        return BaseResponse.getSimpleRes(addId, BaseCode.PATCH);
+        return BaseResponse.getSimpleRes(addId, BaseCode.POST);
     }
 
     @PatchMapping("/{scheduleId}")

--- a/aiku/aiku-main/src/main/java/aiku_main/dto/ScheduleAddDto.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/dto/ScheduleAddDto.java
@@ -9,8 +9,8 @@ import java.time.LocalDateTime;
 @Getter
 @AllArgsConstructor
 public class ScheduleAddDto {
-    public String scheduleName;
-    public Location location;
-    public LocalDateTime scheduleTime;
-    public int pointAmount;
+    private String scheduleName;
+    private Location location;
+    private LocalDateTime scheduleTime;
+    private int pointAmount;
 }

--- a/aiku/aiku-main/src/main/java/aiku_main/dto/ScheduleAddDto.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/dto/ScheduleAddDto.java
@@ -12,4 +12,5 @@ public class ScheduleAddDto {
     public String scheduleName;
     public Location location;
     public LocalDateTime scheduleTime;
+    public int pointAmount;
 }

--- a/aiku/aiku-main/src/main/java/aiku_main/repository/ScheduleRepository.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/repository/ScheduleRepository.java
@@ -1,10 +1,13 @@
 package aiku_main.repository;
 
+import common.domain.ExecStatus;
 import common.domain.Schedule;
 import common.domain.ScheduleMember;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 
@@ -12,4 +15,6 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
             "FROM ScheduleMember sm WHERE sm.member.id = :memberId " +
             "AND sm.schedule.id = :scheduleId AND sm.isOwner = true AND sm.status = 'ALIVE'")
     boolean isScheduleOwner(@Param("memberId") Long memberId, @Param("scheduleId") Long scheduleId);
+
+    List<Schedule> findByScheduleStatus(ExecStatus scheduleStatus);
 }

--- a/aiku/aiku-main/src/main/java/aiku_main/scheduler/ScheduleScheduler.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/scheduler/ScheduleScheduler.java
@@ -46,6 +46,7 @@ public class ScheduleScheduler {
         reserveSchedule(scheduleId, scheduleTime);
     }
 
+    //TODO Runnable 추가
     private void reserveAlarm(Long scheduleId, LocalDateTime scheduleTime){
         Duration delayTime = getDuration(scheduleTime);
         checkDurationValid(delayTime);
@@ -54,6 +55,7 @@ public class ScheduleScheduler {
         scheduleAlarmTasks.put(scheduleId, future);
     }
 
+    //TODO Runnable 추가
     private void reserveMapOpen(Long scheduleId, LocalDateTime scheduleTime){
         Duration delayTime = getDuration(scheduleTime).minus(Duration.ofMinutes(30));
         checkDurationValid(delayTime);
@@ -61,6 +63,8 @@ public class ScheduleScheduler {
         ScheduledFuture<?> future = scheduler.scheduleWithFixedDelay(null, delayTime);
         mapOpenTasks.put(scheduleId, future);
     }
+
+    //TODO Runnable 추가
 
     private void reserveMapClose(Long scheduleId, LocalDateTime scheduleTime){
         Duration delayTime = getDuration(scheduleTime).plus(Duration.ofMinutes(30));

--- a/aiku/aiku-main/src/main/java/aiku_main/scheduler/ScheduleScheduler.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/scheduler/ScheduleScheduler.java
@@ -51,7 +51,7 @@ public class ScheduleScheduler {
         Duration delayTime = getDuration(scheduleTime);
         checkDurationValid(delayTime);
 
-        ScheduledFuture<?> future = scheduler.scheduleWithFixedDelay(null, delayTime);
+        ScheduledFuture<?> future = scheduler.scheduleWithFixedDelay(()->{}, delayTime);
         scheduleAlarmTasks.put(scheduleId, future);
     }
 
@@ -60,7 +60,7 @@ public class ScheduleScheduler {
         Duration delayTime = getDuration(scheduleTime).minus(Duration.ofMinutes(30));
         checkDurationValid(delayTime);
 
-        ScheduledFuture<?> future = scheduler.scheduleWithFixedDelay(null, delayTime);
+        ScheduledFuture<?> future = scheduler.scheduleWithFixedDelay(()->{}, delayTime);
         mapOpenTasks.put(scheduleId, future);
     }
 
@@ -70,22 +70,28 @@ public class ScheduleScheduler {
         Duration delayTime = getDuration(scheduleTime).plus(Duration.ofMinutes(30));
         checkDurationValid(delayTime);
 
-        ScheduledFuture<?> future = scheduler.scheduleWithFixedDelay(null, delayTime);
+        ScheduledFuture<?> future = scheduler.scheduleWithFixedDelay(()->{}, delayTime);
         mapCloseTasks.put(scheduleId, future);
     }
 
     private void cancleAll(Long scheduleId){
         ScheduledFuture future1 = mapOpenTasks.get(scheduleId);
-        future1.cancel(false);
-        mapOpenTasks.remove(scheduleId);
+        if (future1 != null) {
+            future1.cancel(false);
+            mapOpenTasks.remove(scheduleId);
+        }
 
         ScheduledFuture future2 = mapCloseTasks.get(scheduleId);
-        future2.cancel(false);
-        mapCloseTasks.remove(scheduleId);
+        if (future2 != null) {
+            future2.cancel(false);
+            mapCloseTasks.remove(scheduleId);
+        }
 
         ScheduledFuture future3 = scheduleAlarmTasks.get(scheduleId);
-        future3.cancel(false);
-        scheduleAlarmTasks.remove(scheduleId);
+        if (future3 != null) {
+            future3.cancel(false);
+            scheduleAlarmTasks.remove(scheduleId);
+        }
     }
 
     private Duration getDuration(LocalDateTime time){

--- a/aiku/aiku-main/src/main/java/aiku_main/scheduler/ScheduleScheduler.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/scheduler/ScheduleScheduler.java
@@ -1,0 +1,96 @@
+package aiku_main.scheduler;
+
+import aiku_main.repository.ScheduleRepository;
+import common.domain.ExecStatus;
+import common.domain.Schedule;
+import common.exception.BaseExceptionImpl;
+import common.response.status.BaseErrorCode;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledFuture;
+
+
+@RequiredArgsConstructor
+@Component
+public class ScheduleScheduler {
+
+    private final TaskScheduler scheduler;
+    private final ScheduleRepository scheduleRepository;
+
+    private final ConcurrentHashMap<Long, ScheduledFuture> mapOpenTasks = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<Long, ScheduledFuture> mapCloseTasks = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<Long, ScheduledFuture> scheduleAlarmTasks = new ConcurrentHashMap<>();
+
+    @PostConstruct
+    public void initScheduler(){
+        List<Schedule> schedules = scheduleRepository.findByScheduleStatus(ExecStatus.WAIT);
+        schedules.forEach(
+                schedule -> reserveSchedule(schedule.getId(), schedule.getScheduleTime()));
+    }
+
+    public void reserveSchedule(Long scheduleId, LocalDateTime scheduleTime){
+        reserveMapOpen(scheduleId, scheduleTime);
+        reserveMapClose(scheduleId, scheduleTime);
+        reserveAlarm(scheduleId, scheduleTime);
+    }
+
+    public void changeSchedule(Long scheduleId, LocalDateTime scheduleTime){
+        cancleAll(scheduleId);
+        reserveSchedule(scheduleId, scheduleTime);
+    }
+
+    private void reserveAlarm(Long scheduleId, LocalDateTime scheduleTime){
+        Duration delayTime = getDuration(scheduleTime);
+        checkDurationValid(delayTime);
+
+        ScheduledFuture<?> future = scheduler.scheduleWithFixedDelay(null, delayTime);
+        scheduleAlarmTasks.put(scheduleId, future);
+    }
+
+    private void reserveMapOpen(Long scheduleId, LocalDateTime scheduleTime){
+        Duration delayTime = getDuration(scheduleTime).minus(Duration.ofMinutes(30));
+        checkDurationValid(delayTime);
+
+        ScheduledFuture<?> future = scheduler.scheduleWithFixedDelay(null, delayTime);
+        mapOpenTasks.put(scheduleId, future);
+    }
+
+    private void reserveMapClose(Long scheduleId, LocalDateTime scheduleTime){
+        Duration delayTime = getDuration(scheduleTime).plus(Duration.ofMinutes(30));
+        checkDurationValid(delayTime);
+
+        ScheduledFuture<?> future = scheduler.scheduleWithFixedDelay(null, delayTime);
+        mapCloseTasks.put(scheduleId, future);
+    }
+
+    private void cancleAll(Long scheduleId){
+        ScheduledFuture future1 = mapOpenTasks.get(scheduleId);
+        future1.cancel(false);
+        mapOpenTasks.remove(scheduleId);
+
+        ScheduledFuture future2 = mapCloseTasks.get(scheduleId);
+        future2.cancel(false);
+        mapCloseTasks.remove(scheduleId);
+
+        ScheduledFuture future3 = scheduleAlarmTasks.get(scheduleId);
+        future3.cancel(false);
+        scheduleAlarmTasks.remove(scheduleId);
+    }
+
+    private Duration getDuration(LocalDateTime time){
+        return Duration.between(LocalDateTime.now(), time);
+    }
+
+    private void checkDurationValid(Duration duration){
+        if(duration.toMinutes() < 0){
+            throw new BaseExceptionImpl(BaseErrorCode.NO_VALID_SCHEDULE_TIME);
+        }
+    }
+}

--- a/aiku/aiku-main/src/main/java/aiku_main/service/ScheduleService.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/service/ScheduleService.java
@@ -31,6 +31,7 @@ public class ScheduleService {
     private final ScheduleRepository scheduleRepository;
     private final PointChangeEventPublisher pointChangeEventPublisher;
 
+    //TODO 알림 추가하는 카프카 로직 추가해야됨
     @Transactional
     public Long addSchedule(Member member, Long teamId, ScheduleAddDto scheduleDto){
         //검증 로직
@@ -47,6 +48,7 @@ public class ScheduleService {
         return schedule.getId();
     }
 
+    //TODO 시간 바꿨을때 알림등 바꾸는 로직 추가해야됨
     @Transactional
     public Long updateSchedule(Member member, Long scheduleId, ScheduleUpdateDto scheduleDto){
         //검증 로직

--- a/aiku/aiku-main/src/main/java/aiku_main/service/ScheduleService.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/service/ScheduleService.java
@@ -7,6 +7,7 @@ import common.domain.Member;
 import common.domain.Schedule;
 import common.domain.Status;
 import common.exception.NoAuthorityException;
+import common.exception.NotEnoughPoint;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -22,11 +23,29 @@ public class ScheduleService {
 
     private final ScheduleRepository scheduleRepository;
 
-    public Long addSchedule(ScheduleAddDto scheduleDto){
+    /**
+     * 스케줄 등록
+     * 참가비
+     * 약속 참가자로 등록
+     * 부족하면 예외
+     */
+    @Transactional
+    public Long addSchedule(Member member, Long teamId, ScheduleAddDto scheduleDto){
+        //검증 로직
+        checkEnoughPoint(member, scheduleDto.getPointAmount());
 
-        return null;
+        //서비스 로직
+        //TODO 멤버 포인트 지불
+
+        Schedule schedule = Schedule.create(member, teamId,
+                scheduleDto.getScheduleName(), scheduleDto.getScheduleTime(), scheduleDto.getLocation(),
+                scheduleDto.getPointAmount());
+        scheduleRepository.save(schedule);
+
+        return schedule.getId();
     }
 
+    @Transactional
     public Long updateSchedule(Member member, Long scheduleId, ScheduleUpdateDto scheduleDto){
         //검증 로직
         checkIsOwner(member.getId(), scheduleId);
@@ -41,12 +60,20 @@ public class ScheduleService {
     }
 
     private void checkIsAlive(Schedule schedule){
-        if(schedule.getStatus() == Status.DELETE) throw new NoSuchElementException();
+        if(schedule.getStatus() == Status.DELETE){
+            throw new NoSuchElementException();
+        }
     }
 
     private void checkIsOwner(Long memberId, Long scheduleId){
         if(!scheduleRepository.isScheduleOwner(memberId, scheduleId)){
             throw new NoAuthorityException();
+        }
+    }
+
+    private void checkEnoughPoint(Member member, int point){
+        if(member.getPoint() < point){
+            throw new NotEnoughPoint();
         }
     }
 

--- a/aiku/aiku-main/src/main/java/aiku_main/service/ScheduleService.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/service/ScheduleService.java
@@ -43,7 +43,7 @@ public class ScheduleService {
         scheduleRepository.save(schedule);
 
         pointChangeEventPublisher.publish(member.getId(), MINUS, scheduleDto.getPointAmount(), SCHEDULE, schedule.getId());
-        
+
         return schedule.getId();
     }
 

--- a/aiku/aiku-main/src/test/java/aiku_main/integration_test/ScheduleServiceIntegrationTest.java
+++ b/aiku/aiku-main/src/test/java/aiku_main/integration_test/ScheduleServiceIntegrationTest.java
@@ -55,7 +55,7 @@ public class ScheduleServiceIntegrationTest {
 
         //when
         ScheduleUpdateDto scheduleDto = new ScheduleUpdateDto("new",
-                new Location("new", 2.0, 2.0), LocalDateTime.now());
+                new Location("new", 2.0, 2.0), LocalDateTime.now().plusHours(2));
         scheduleService.updateSchedule(member, schedule.getId(), scheduleDto);
 
         //then

--- a/aiku/aiku-main/src/test/java/aiku_main/integration_test/ScheduleServiceIntegrationTest.java
+++ b/aiku/aiku-main/src/test/java/aiku_main/integration_test/ScheduleServiceIntegrationTest.java
@@ -1,0 +1,74 @@
+package aiku_main.integration_test;
+
+import aiku_main.dto.ScheduleUpdateDto;
+import aiku_main.repository.ScheduleRepository;
+import aiku_main.service.ScheduleService;
+import common.domain.Location;
+import common.domain.Member;
+import common.domain.Schedule;
+import common.domain.Team;
+import common.exception.NoAuthorityException;
+import jakarta.persistence.EntityManager;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Random;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Transactional
+@SpringBootTest
+public class ScheduleServiceIntegrationTest {
+
+    @Autowired
+    EntityManager em;
+
+    @Autowired
+    ScheduleService scheduleService;
+
+    @Autowired
+    ScheduleRepository scheduleRepository;
+
+    Random random = new Random();
+
+    @Test
+    @DisplayName("스케줄 수정(권한O&X)")
+    void updateSchedule() {
+        //given
+        Member member = Member.create("member1");
+        Member member2 = Member.create("member2");
+        em.persist(member);
+        em.persist(member2);
+
+        Team team = Team.create(member, "team1");
+        em.persist(team);
+
+        Schedule schedule = createSchedule(member, team.getId(), 0);
+        em.persist(schedule);
+
+        //when
+        ScheduleUpdateDto scheduleDto = new ScheduleUpdateDto("new",
+                new Location("new", 2.0, 2.0), LocalDateTime.now());
+        scheduleService.updateSchedule(member, schedule.getId(), scheduleDto);
+
+        //then
+        Schedule findSchedule = scheduleRepository.findById(schedule.getId()).get();
+        assertThat(findSchedule.getScheduleName()).isEqualTo(scheduleDto.getScheduleName());
+        assertThat(findSchedule.getLocation().getLocationName()).isEqualTo(scheduleDto.getLocation().getLocationName());
+
+        //권한 x
+        assertThatThrownBy(() -> scheduleService.updateSchedule(member2, schedule.getId(), scheduleDto)).isInstanceOf(NoAuthorityException.class);
+    }
+
+    Schedule createSchedule(Member member, Long teamId, int pointAmount){
+        return Schedule.create(member, teamId, UUID.randomUUID().toString(), LocalDateTime.now(),
+                new Location(UUID.randomUUID().toString(), random.nextDouble(), random.nextDouble()), pointAmount);
+    }
+}

--- a/aiku/aiku-main/src/test/java/aiku_main/integration_test/TeamServiceIntegrationTest.java
+++ b/aiku/aiku-main/src/test/java/aiku_main/integration_test/TeamServiceIntegrationTest.java
@@ -1,0 +1,54 @@
+package aiku_main.integration_test;
+
+import aiku_main.dto.TeamAddDto;
+import aiku_main.repository.TeamRepository;
+import aiku_main.service.TeamService;
+import common.domain.Member;
+import common.domain.Team;
+import common.domain.TeamMember;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Transactional
+@SpringBootTest
+public class TeamServiceIntegrationTest {
+
+    @Autowired
+    EntityManager em;
+
+    @Autowired
+    TeamService teamService;
+
+    @Autowired
+    TeamRepository teamRepository;
+
+    @Test
+    @DisplayName("그룹 등록")
+    void addTeam() {
+        //given
+        Member member = Member.create("member1");
+        em.persist(member);
+
+        //when
+        TeamAddDto teamDto = new TeamAddDto("group1");
+        Long teamId = teamService.addTeam(member, teamDto);
+
+        em.flush();
+        em.clear();
+
+        //then
+        Team team = teamRepository.findById(teamId).get();
+        assertThat(team.getTeamName()).isEqualTo(teamDto.getGroupName());
+        assertThat(team.getTeamMembers().size()).isEqualTo(1);
+
+        TeamMember teamMember = team.getTeamMembers().get(0);
+        assertThat(teamMember.isOwner()).isTrue();
+        assertThat(teamMember.getMember().getId()).isEqualTo(member.getId());
+    }
+}

--- a/aiku/aiku-main/src/test/java/aiku_main/service/ScheduleServiceTest.java
+++ b/aiku/aiku-main/src/test/java/aiku_main/service/ScheduleServiceTest.java
@@ -5,19 +5,19 @@ import aiku_main.repository.ScheduleRepository;
 import common.domain.Location;
 import common.domain.Member;
 import common.domain.Schedule;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
+import java.util.Random;
 
+import static java.lang.Math.random;
+import static java.util.UUID.randomUUID;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -30,13 +30,18 @@ class ScheduleServiceTest {
     ScheduleService scheduleService;
 
     @Test
+    void create(){
+
+    }
+
+    @Test
     void updateSchedule() {
         //given
-        Member member = new Member("member1");
-        Schedule schedule = Schedule.create(member, null,
-                "original schedule name", LocalDateTime.now(),
-                new Location("original location", 1.1, 1.1));
+        Member member = createSpyMember();
+        Schedule schedule = createSpySchedule(member, null, 0);
+        Long scheduleId = getRandomId();
 
+        doReturn(scheduleId).when(schedule).getId();
         when(scheduleRepository.findById(nullable(Long.class))).thenReturn(Optional.of(schedule));
         when(scheduleRepository.isScheduleOwner(nullable(Long.class), nullable(Long.class))).thenReturn(true);
 
@@ -44,10 +49,26 @@ class ScheduleServiceTest {
         ScheduleUpdateDto scheduleDto = new ScheduleUpdateDto("new Schedule",
                 new Location("new location", 2.2, 2.2),
                 LocalDateTime.now());
-        scheduleService.updateSchedule(member, schedule.getId(), scheduleDto);
+        Long resultId = scheduleService.updateSchedule(member, schedule.getId(), scheduleDto);
 
         //then
+        assertThat(resultId).isEqualTo(scheduleId);
         assertThat(schedule.getScheduleName()).isEqualTo(scheduleDto.getScheduleName());
         assertThat(schedule.getLocation()).isEqualTo(scheduleDto.getLocation());
+    }
+
+    Member createSpyMember(){
+        return spy(new Member(randomUUID().toString()));
+    }
+
+    Schedule createSpySchedule(Member member, Long teamId, int pointAmount){
+        return spy(Schedule.create(member, null,
+                randomUUID().toString(), LocalDateTime.now(),
+                new Location(randomUUID().toString(), random(), random()), pointAmount));
+    }
+
+    Long getRandomId(){
+        Random random = new Random();
+        return random.nextLong();
     }
 }

--- a/aiku/aiku-main/src/test/java/aiku_main/service/ScheduleServiceTest.java
+++ b/aiku/aiku-main/src/test/java/aiku_main/service/ScheduleServiceTest.java
@@ -30,11 +30,6 @@ class ScheduleServiceTest {
     ScheduleService scheduleService;
 
     @Test
-    void create(){
-
-    }
-
-    @Test
     void updateSchedule() {
         //given
         Member member = createSpyMember();

--- a/aiku/aiku-main/src/test/java/aiku_main/service/ScheduleServiceTest.java
+++ b/aiku/aiku-main/src/test/java/aiku_main/service/ScheduleServiceTest.java
@@ -2,6 +2,7 @@ package aiku_main.service;
 
 import aiku_main.dto.ScheduleUpdateDto;
 import aiku_main.repository.ScheduleRepository;
+import aiku_main.scheduler.ScheduleScheduler;
 import common.domain.Location;
 import common.domain.Member;
 import common.domain.Schedule;
@@ -25,6 +26,9 @@ class ScheduleServiceTest {
 
     @Mock
     ScheduleRepository scheduleRepository;
+
+    @Mock
+    ScheduleScheduler scheduleScheduler;
 
     @InjectMocks
     ScheduleService scheduleService;


### PR DESCRIPTION
## 관련 이슈 번호

- #5 

<br />

## 작업 사항

- 스케줄 등록/수정에 따른 부가 서비스 로직 예약을 위한 Scheduler패키지에 TaskScheduler 생성
- 스케줄 등록/수정에 알림, 맵 오픈등 로직 예약 추가
- 로직 변동에 따른 스케줄 서비스 테스트 수정
- 스케줄 엔티티 편의 메서드 테스트 추가

<br />

## 기타 사항

- TaskScheduler의 실행 Task가 아직 구현이 안되어 있음. 후에 Kafka 연동해서 Runnable 구현해야됨

<br />
