### PR TITLE
그룹 지각 랭킹 분석 개발

### DIFF
--- a/aiku/aiku-common/src/main/java/common/domain/schedule/ScheduleResult.java
+++ b/aiku/aiku-common/src/main/java/common/domain/schedule/ScheduleResult.java
@@ -26,11 +26,11 @@ public class ScheduleResult extends BaseTime {
     @Lob
     private String scheduleRacingResult;
 
-    //==편의 메서드==
-    protected void setSchedule(Schedule schedule) {
+    protected ScheduleResult(Schedule schedule) {
         this.schedule = schedule;
     }
 
+    //==편의 메서드==
     protected void setScheduleArrivalResult(String scheduleArrivalResult) {
         this.scheduleArrivalResult = scheduleArrivalResult;
     }

--- a/aiku/aiku-common/src/main/java/common/domain/team/Team.java
+++ b/aiku/aiku-common/src/main/java/common/domain/team/Team.java
@@ -8,6 +8,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -23,6 +24,9 @@ public class Team extends BaseTime {
 
     @OneToMany(mappedBy = "team", cascade = CascadeType.ALL)
     private List<TeamMember> teamMembers = new ArrayList<>();
+
+    @OneToOne(fetch = FetchType.EAGER, cascade = CascadeType.ALL, orphanRemoval = true)
+    private TeamResult teamResult;
 
     @Enumerated(value = EnumType.STRING)
     private Status status = Status.ALIVE;
@@ -52,5 +56,23 @@ public class Team extends BaseTime {
 
     public void removeTeamMember(TeamMember teamMember){
         teamMember.setStatus(Status.DELETE);
+    }
+
+    public void setTeamLateResult(String teamLateResult){
+        checkTeamResultExist();
+        teamResult.setLateTimeResult(teamLateResult);
+    }
+
+    public LocalDateTime getTeamResultLastModifiedAt(){
+        if (teamResult == null) {
+            return null;
+        }
+        return teamResult.getModifiedAt();
+    }
+
+    private void checkTeamResultExist(){
+        if (teamResult == null) {
+            teamResult = new TeamResult(this);
+        }
     }
 }

--- a/aiku/aiku-common/src/main/java/common/domain/team/TeamResult.java
+++ b/aiku/aiku-common/src/main/java/common/domain/team/TeamResult.java
@@ -19,7 +19,29 @@ public class TeamResult extends BaseTime {
     @OneToOne(fetch = FetchType.LAZY)
     private Team team;
 
+    @Lob
     private String lateTimeResult;
+
+    @Lob
     private String teamBettingResult;
+
+    @Lob
     private String teamRacingResult;
+
+    protected TeamResult(Team team) {
+        this.team = team;
+    }
+
+    //==편의 메서드==
+    protected void setLateTimeResult(String lateTimeResult) {
+        this.lateTimeResult = lateTimeResult;
+    }
+
+    protected void setTeamBettingResult(String teamBettingResult) {
+        this.teamBettingResult = teamBettingResult;
+    }
+
+    protected void setTeamRacingResult(String teamRacingResult) {
+        this.teamRacingResult = teamRacingResult;
+    }
 }

--- a/aiku/aiku-common/src/main/java/common/domain/value_reference/ScheduleValue.java
+++ b/aiku/aiku-common/src/main/java/common/domain/value_reference/ScheduleValue.java
@@ -7,7 +7,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
 @Embeddable
 public class ScheduleValue {
 

--- a/aiku/aiku-main/src/main/java/aiku_main/application_event/domain/TeamLateTimeResult.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/application_event/domain/TeamLateTimeResult.java
@@ -1,0 +1,15 @@
+package aiku_main.application_event.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TeamLateTimeResult {
+    private Long groupId;
+    private List<TeamResultMember> members;
+}

--- a/aiku/aiku-main/src/main/java/aiku_main/application_event/domain/TeamResultMember.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/application_event/domain/TeamResultMember.java
@@ -1,0 +1,27 @@
+package aiku_main.application_event.domain;
+
+import aiku_main.dto.MemberProfileResDto;
+import com.querydsl.core.annotations.QueryProjection;
+import common.domain.Status;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter @Setter
+@NoArgsConstructor
+public class TeamResultMember {
+    private Long memberId;
+    private String nickname;
+    private MemberProfileResDto memberProfile;
+    private int analysis;
+    private boolean isTeamMember;
+
+    @QueryProjection
+    public TeamResultMember(Long memberId, String nickname, MemberProfileResDto memberProfile, int analysis, Status teamMemberStatus) {
+        this.memberId = memberId;
+        this.nickname = nickname;
+        this.memberProfile = memberProfile;
+        this.analysis = analysis;
+        this.isTeamMember = teamMemberStatus == Status.ALIVE ? true : false;
+    }
+}

--- a/aiku/aiku-main/src/main/java/aiku_main/application_event/event/ScheduleAutoCloseEvent.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/application_event/event/ScheduleAutoCloseEvent.java
@@ -1,11 +1,18 @@
 package aiku_main.application_event.event;
 
+import common.domain.schedule.Schedule;
+import common.domain.team.Team;
+import common.domain.value_reference.ScheduleValue;
+import common.domain.value_reference.TeamValue;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-@AllArgsConstructor
 @Getter
 public class ScheduleAutoCloseEvent {
 
-    private Long scheduleId;
+    private ScheduleValue schedule;
+
+    public ScheduleAutoCloseEvent(Schedule schedule) {
+        this.schedule = new ScheduleValue(schedule);
+    }
 }

--- a/aiku/aiku-main/src/main/java/aiku_main/application_event/event/ScheduleOpenEvent.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/application_event/event/ScheduleOpenEvent.java
@@ -1,11 +1,16 @@
 package aiku_main.application_event.event;
 
+import common.domain.schedule.Schedule;
+import common.domain.value_reference.ScheduleValue;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-@AllArgsConstructor
 @Getter
 public class ScheduleOpenEvent {
 
-    private Long scheduleId;
+    private ScheduleValue schedule;
+
+    public ScheduleOpenEvent(Schedule schedule) {
+        this.schedule = new ScheduleValue(schedule);
+    }
 }

--- a/aiku/aiku-main/src/main/java/aiku_main/application_event/handler/BettingHandler.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/application_event/handler/BettingHandler.java
@@ -23,7 +23,7 @@ public class BettingHandler {
 
     @EventListener
     public void handleScheduleAutoCloseEvent(ScheduleAutoCloseEvent event){
-        bettingService.processBettingResult(event.getScheduleId());
-        bettingService.analyzeScheduleBettingResult(event.getScheduleId());
+        bettingService.processBettingResult(event.getSchedule().getId());
+        bettingService.analyzeScheduleBettingResult(event.getSchedule().getId());
     }
 }

--- a/aiku/aiku-main/src/main/java/aiku_main/application_event/handler/ScheduleHandler.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/application_event/handler/ScheduleHandler.java
@@ -25,15 +25,15 @@ public class ScheduleHandler {
 
     @EventListener
     public void handleScheduleOpenEvent(ScheduleOpenEvent event){
-        scheduleService.scheduleOpen(event.getScheduleId());
+        scheduleService.scheduleOpen(event.getSchedule().getId());
     }
 
     @Async
     @Order(1)
     @EventListener
     public void handleScheduleAutoCloseEvent(ScheduleAutoCloseEvent event){
-        scheduleService.scheduleAutoClose(event.getScheduleId());
-        scheduleService.processScheduleResultPoint(event.getScheduleId());
-        scheduleService.analyzeScheduleArrivalResult(event.getScheduleId());
+        scheduleService.scheduleAutoClose(event.getSchedule().getId());
+        scheduleService.processScheduleResultPoint(event.getSchedule().getId());
+        scheduleService.analyzeScheduleArrivalResult(event.getSchedule().getId());
     }
 }

--- a/aiku/aiku-main/src/main/java/aiku_main/application_event/handler/TeamHandler.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/application_event/handler/TeamHandler.java
@@ -1,0 +1,19 @@
+package aiku_main.application_event.handler;
+
+import aiku_main.application_event.event.ScheduleAutoCloseEvent;
+import aiku_main.service.TeamService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class TeamHandler {
+
+    private final TeamService teamService;
+
+    @EventListener
+    public void handleScheduleAutoCloseEvent(ScheduleAutoCloseEvent event){
+        teamService.analyzeLateTimeResult(event.getSchedule().getId());
+    }
+}

--- a/aiku/aiku-main/src/main/java/aiku_main/application_event/publisher/ScheduleEventPublisher.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/application_event/publisher/ScheduleEventPublisher.java
@@ -7,6 +7,7 @@ import aiku_main.application_event.event.ScheduleOpenEvent;
 import common.domain.schedule.Schedule;
 import common.domain.schedule.ScheduleMember;
 import common.domain.member.Member;
+import common.domain.team.Team;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
@@ -22,13 +23,13 @@ public class ScheduleEventPublisher {
         publisher.publishEvent(event);
     }
 
-    public void publishScheduleOpenEvent(Long scheduleId){
-        ScheduleOpenEvent event = new ScheduleOpenEvent(scheduleId);
+    public void publishScheduleOpenEvent(Schedule schedule){
+        ScheduleOpenEvent event = new ScheduleOpenEvent(schedule);
         publisher.publishEvent(event);
     }
 
-    public void publishScheduleAutoCloseEvent(Long scheduleId){
-        ScheduleAutoCloseEvent event = new ScheduleAutoCloseEvent(scheduleId);
+    public void publishScheduleAutoCloseEvent(Schedule schedule){
+        ScheduleAutoCloseEvent event = new ScheduleAutoCloseEvent(schedule);
         publisher.publishEvent(event);
     }
 

--- a/aiku/aiku-main/src/main/java/aiku_main/dto/MemberProfileResDto.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/dto/MemberProfileResDto.java
@@ -7,7 +7,9 @@ import common.domain.member.MemberProfileCharacter;
 import common.domain.member.MemberProfileType;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor
 @Getter
 public class MemberProfileResDto{
 

--- a/aiku/aiku-main/src/main/java/aiku_main/repository/TeamReadRepository.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/repository/TeamReadRepository.java
@@ -1,5 +1,6 @@
 package aiku_main.repository;
 
+import aiku_main.application_event.domain.TeamResultMember;
 import aiku_main.dto.TeamEachListResDto;
 import aiku_main.dto.TotalCountDto;
 import common.domain.team.Team;
@@ -11,4 +12,6 @@ public interface TeamReadRepository {
 
     Optional<Team> findTeamWithMember(Long teamId);
     List<TeamEachListResDto> getTeamList(Long memberId, int page, TotalCountDto totalCount);
+
+    List<TeamResultMember> getTeamLateTimeResult(Long teamId);
 }

--- a/aiku/aiku-main/src/main/java/aiku_main/service/BettingService.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/service/BettingService.java
@@ -236,7 +236,7 @@ public class BettingService {
     }
 
     private void checkBettingMember(Betting betting, ScheduleMember bettor){
-        if(betting.getBettor().getId() != bettor.getId()){
+        if(!betting.getBettor().getId().equals(bettor.getId())){
             throw new NoAuthorityException();
         }
     }

--- a/aiku/aiku-main/src/main/java/aiku_main/service/ScheduleService.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/service/ScheduleService.java
@@ -69,7 +69,7 @@ public class ScheduleService {
         scheduleRepository.save(schedule);
 
         pointChangeEventPublisher.publish(member, MINUS, scheduleDto.getPointAmount(), SCHEDULE, schedule.getId());
-        scheduleScheduler.reserveSchedule(schedule.getId(), schedule.getScheduleTime());
+        scheduleScheduler.reserveSchedule(schedule);
 
         return schedule.getId();
     }
@@ -89,7 +89,7 @@ public class ScheduleService {
         //서비스 로직
         schedule.update(scheduleDto.getScheduleName(), scheduleDto.getScheduleTime(), scheduleDto.location.toDomain());
 
-        scheduleScheduler.changeSchedule(schedule.getId(), schedule.getScheduleTime());
+        scheduleScheduler.changeSchedule(schedule);
 
         return schedule.getId();
     }
@@ -214,7 +214,7 @@ public class ScheduleService {
     @Transactional
     public void scheduleOpen(Long scheduleId) {
         Schedule schedule = scheduleRepository.findById(scheduleId).orElseThrow();
-        schedule.setScheduleStatus(ExecStatus.RUN);
+        schedule.setRun();
 
         //TODO 카프카, 알림
     }

--- a/aiku/aiku-main/src/test/java/aiku_main/integration_test/BettingServiceIntegrationTest.java
+++ b/aiku/aiku-main/src/test/java/aiku_main/integration_test/BettingServiceIntegrationTest.java
@@ -110,7 +110,7 @@ class BettingServiceIntegrationTest {
     @Test
     void 베팅_등록_대기스케줄x() {
         //given
-        schedule1.setScheduleStatus(TERM);
+        schedule1.setTerm(LocalDateTime.now());
 
         //when
         BettingAddDto bettingDto = new BettingAddDto(member2.getId(), 0);

--- a/aiku/aiku-main/src/test/java/aiku_main/integration_test/ScheduleServiceIntegrationTest.java
+++ b/aiku/aiku-main/src/test/java/aiku_main/integration_test/ScheduleServiceIntegrationTest.java
@@ -253,7 +253,7 @@ public class ScheduleServiceIntegrationTest {
         em.persist(team);
 
         Schedule schedule = createSchedule(member1, team, 100);
-        schedule.setScheduleStatus(ExecStatus.RUN);
+        schedule.setRun();
         em.persist(schedule);
 
         em.flush();
@@ -405,7 +405,7 @@ public class ScheduleServiceIntegrationTest {
         em.persist(team);
 
         Schedule schedule = createSchedule(member1, team, 0);
-        schedule.setScheduleStatus(ExecStatus.TERM);
+        schedule.setTerm(LocalDateTime.now());
         schedule.addScheduleMember(member2, false, 0);
 
         em.persist(schedule);
@@ -480,16 +480,14 @@ public class ScheduleServiceIntegrationTest {
         Schedule schedule1 = createSchedule(member1, team, 100);
         schedule1.addScheduleMember(member2, false, 0);
         schedule1.addScheduleMember(member3, false, 100);
-        schedule1.setScheduleStatus(ExecStatus.RUN);
+        schedule1.setRun();
         em.persist(schedule1);
 
         Schedule schedule2 = createSchedule(member2, team, 100);
         schedule2.addScheduleMember(member3, false, 100);
-        schedule2.setScheduleStatus(ExecStatus.WAIT);
         em.persist(schedule2);
 
         Schedule schedule3 = createSchedule(member3, team, 100);
-        schedule3.setScheduleStatus(ExecStatus.WAIT);
         em.persist(schedule3);
 
         em.flush();
@@ -529,19 +527,17 @@ public class ScheduleServiceIntegrationTest {
         em.persist(team);
 
         Schedule schedule1 = createSchedule(member1, team, 100);
-        schedule1.setScheduleStatus(ExecStatus.RUN);
+        schedule1.setRun();
         em.persist(schedule1);
 
         LocalDateTime startDate = LocalDateTime.now().plusHours(3);
 
         Schedule schedule2 = createSchedule(member2, team, 100);
-        schedule2.setScheduleStatus(ExecStatus.WAIT);
         em.persist(schedule2);
 
         LocalDateTime endDate = LocalDateTime.now().plusHours(3);
 
         Schedule schedule3 = createSchedule(member3, team, 100);
-        schedule3.setScheduleStatus(ExecStatus.WAIT);
         em.persist(schedule3);
 
         em.flush();
@@ -576,16 +572,15 @@ public class ScheduleServiceIntegrationTest {
         em.persist(teamB);
 
         Schedule scheduleA1 = createSchedule(member1, teamA, 100);
-        scheduleA1.setScheduleStatus(ExecStatus.RUN);
+        scheduleA1.setRun();
         scheduleA1.addScheduleMember(member2, false, 0);
         em.persist(scheduleA1);
 
         Schedule scheduleA2 = createSchedule(member2, teamA, 100);
-        scheduleA2.setScheduleStatus(ExecStatus.WAIT);
         em.persist(scheduleA2);
 
         Schedule scheduleB1 = createSchedule(member1, teamB, 0);
-        scheduleB1.setScheduleStatus(ExecStatus.RUN);
+        scheduleB1.setRun();
         em.persist(scheduleB1);
 
         em.flush();
@@ -618,22 +613,20 @@ public class ScheduleServiceIntegrationTest {
         em.persist(teamB);
 
         Schedule scheduleA1 = createSchedule(member1, teamA, 100);
-        scheduleA1.setScheduleStatus(ExecStatus.RUN);
+        scheduleA1.setRun();
         scheduleA1.addScheduleMember(member2, false, 0);
         em.persist(scheduleA1);
 
         Schedule scheduleA2 = createSchedule(member2, teamA, 100);
-        scheduleA2.setScheduleStatus(ExecStatus.WAIT);
         em.persist(scheduleA2);
 
         LocalDateTime startDate = LocalDateTime.now().plusHours(3);
 
         Schedule scheduleB1 = createSchedule(member1, teamB, 0);
-        scheduleB1.setScheduleStatus(ExecStatus.RUN);
+        scheduleB1.setRun();
         em.persist(scheduleB1);
 
         Schedule scheduleB2 = createSchedule(member1, teamB, 0);
-        scheduleB2.setScheduleStatus(ExecStatus.WAIT);
         em.persist(scheduleB2);
 
         em.flush();
@@ -670,7 +663,7 @@ public class ScheduleServiceIntegrationTest {
 
         Schedule schedule3 = createSchedule(member1, team, 0);
         schedule3.addScheduleMember(member2, false, 0);
-        schedule3.setScheduleStatus(ExecStatus.TERM);
+        schedule3.setTerm(LocalDateTime.now());
         em.persist(schedule3);
 
         Team teamB = Team.create(member1, "teamB");
@@ -741,7 +734,7 @@ public class ScheduleServiceIntegrationTest {
         LocalDateTime arrivalTime = LocalDateTime.now();
         schedule1.arriveScheduleMember(schedule1.getScheduleMembers().get(0), arrivalTime);
         schedule1.arriveScheduleMember(schedule1.getScheduleMembers().get(1), arrivalTime);
-        schedule1.setScheduleStatus(ExecStatus.TERM);
+        schedule1.setTerm(LocalDateTime.now());
 
         em.persist(schedule1);
 
@@ -779,7 +772,7 @@ public class ScheduleServiceIntegrationTest {
         schedule1.arriveScheduleMember(schedule1.getScheduleMembers().get(0), arrivalTime);
         schedule1.arriveScheduleMember(schedule1.getScheduleMembers().get(1), arrivalTime);
         schedule1.arriveScheduleMember(schedule1.getScheduleMembers().get(2), arrivalTime);
-        schedule1.setScheduleStatus(ExecStatus.TERM);
+        schedule1.setTerm(LocalDateTime.now());
 
         em.persist(schedule1);
 
@@ -815,7 +808,7 @@ public class ScheduleServiceIntegrationTest {
         schedule1.arriveScheduleMember(schedule1.getScheduleMembers().get(0), arrivalTime);
         schedule1.arriveScheduleMember(schedule1.getScheduleMembers().get(1), arrivalTime);
         schedule1.arriveScheduleMember(schedule1.getScheduleMembers().get(2), arrivalTime);
-        schedule1.setScheduleStatus(ExecStatus.TERM);
+        schedule1.setTerm(LocalDateTime.now());
 
         em.persist(schedule1);
 
@@ -851,7 +844,7 @@ public class ScheduleServiceIntegrationTest {
         schedule1.arriveScheduleMember(schedule1.getScheduleMembers().get(0), arrivalTime.plusHours(5));
         schedule1.arriveScheduleMember(schedule1.getScheduleMembers().get(1), arrivalTime);
         schedule1.arriveScheduleMember(schedule1.getScheduleMembers().get(2), arrivalTime);
-        schedule1.setScheduleStatus(ExecStatus.TERM);
+        schedule1.setTerm(LocalDateTime.now());
 
         em.persist(schedule1);
 
@@ -887,7 +880,7 @@ public class ScheduleServiceIntegrationTest {
         schedule1.arriveScheduleMember(schedule1.getScheduleMembers().get(0), arrivalTime.plusHours(4));
         schedule1.arriveScheduleMember(schedule1.getScheduleMembers().get(1), arrivalTime.plusHours(3).plusMinutes(10));
         schedule1.arriveScheduleMember(schedule1.getScheduleMembers().get(2), arrivalTime.plusHours(3));
-        schedule1.setScheduleStatus(ExecStatus.TERM);
+        schedule1.setTerm(LocalDateTime.now());
 
         em.persist(schedule1);
 


### PR DESCRIPTION
## 관련 이슈 번호

- #19 

<br />

## 작업 사항

- 스케줄 자동 종료 시간 마다 그룹 분석이 업데이트 되지 않았다면, 그룹의 지각 결과 분석 로직 개발 및 통합 테스트
- Schedule 엔티티 리팩토링

<br />

## 기타 사항

- Schedule엔티티에 스케줄 종료 시각인 scheduleTermTime 추가
- Schedule생성시 default로 ScheduleResult를 생성했던 것을 DB 최적화를 위해 ScheduleResult 내부 필드를 set할때 생성하는 것으로 변경
- 현재 Schedule 메서드에서 ScheduleMember를 파라미터로 받아 멤버에게 보상 및 결과를 update하고 있음. 이로 인해 어그리거트는 일관되게 유지할 수 있으나 문제는 Schedule 내부의 ScheduleMember가 아니더라도 모든 ScheduleMember 수정이 가능함. 이에 대한 고민 필요.

<br />
