### PR TITLE
사용자 개별 FCM 토큰 저장 및 수정 로직 작성

### DIFF
--- a/aiku/aiku-common/src/main/java/common/domain/member/Member.java
+++ b/aiku/aiku-common/src/main/java/common/domain/member/Member.java
@@ -45,6 +45,9 @@ public class Member extends BaseTime {
     @Enumerated(value = EnumType.STRING)
     private Status status;
 
+    private String firebaseToken;
+
+
     public void reissueRefreshToken(String refreshToken) {
         this.refreshToken = refreshToken;
     }
@@ -90,6 +93,10 @@ public class Member extends BaseTime {
 
     public void updateMemberTitleByTitleMemberId(TitleMemberValue titleMemberValue) {
         this.mainTitle = titleMemberValue;
+    }
+
+    public void updateFirebaseToken(String firebaseToken) {
+        this.firebaseToken = firebaseToken;
     }
 
     public void logout() {

--- a/aiku/aiku-common/src/main/java/common/response/status/BaseErrorCode.java
+++ b/aiku/aiku-common/src/main/java/common/response/status/BaseErrorCode.java
@@ -28,6 +28,8 @@ public enum BaseErrorCode implements StatusCode{
     CAN_NOT_EXIT(40016, "실행중인 스케줄이 있습니다.", HttpStatus.BAD_REQUEST),
     NO_TERM_SCHEDULE(40017, "스케줄이 아직 종료되지 않았습니다.", HttpStatus.BAD_REQUEST),
     ALREADY_HAS_BETTING(40018, "이미 베팅이 존재합니다.", HttpStatus.BAD_REQUEST),
+    DUPLICATED_FCM_TOKEN(40019, "중복된 파이어베이스 토큰입니다.", HttpStatus.BAD_REQUEST),
+    NO_FCM_TOKEN(40020, "파이어베이스 토큰이 존재하지 않습니다.", HttpStatus.BAD_REQUEST),
 
     NO_SCHEDULE_OWNER(40301, "스케줄장이 아닙니다.", HttpStatus.FORBIDDEN),
     NOT_AVAILABLE_SCHEDULE(40302, "이용 불가능한 스케줄입니다.", HttpStatus.FORBIDDEN),

--- a/aiku/aiku-main/src/main/java/aiku_main/controller/FirebaseController.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/controller/FirebaseController.java
@@ -1,0 +1,33 @@
+package aiku_main.controller;
+
+import aiku_main.dto.*;
+import aiku_main.service.LoginService;
+import aiku_main.service.MemberFirebaseService;
+import common.domain.member.Member;
+import common.response.BaseResponse;
+import common.response.BaseResultDto;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RequestMapping("/users/alarm/token")
+@RequiredArgsConstructor
+@RestController
+public class FirebaseController {
+
+    private final MemberFirebaseService memberFirebaseService;
+
+    @PostMapping
+    public BaseResponse<BaseResultDto> saveToken(@RequestBody Long accessMemberId, @RequestBody @Valid FirebaseTokenDto firebaseTokenDto) {
+        Long memberId = memberFirebaseService.saveToken(accessMemberId, firebaseTokenDto);
+
+        return BaseResponse.getSimpleRes(memberId);
+    }
+
+    @PatchMapping
+    public BaseResponse<BaseResultDto> updateToken(@RequestBody Long accessMemberId, @RequestBody @Valid FirebaseTokenDto firebaseTokenDto) {
+        Long memberId = memberFirebaseService.updateToken(accessMemberId, firebaseTokenDto);
+
+        return BaseResponse.getSimpleRes(memberId);
+    }
+}

--- a/aiku/aiku-main/src/main/java/aiku_main/dto/FirebaseTokenDto.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/dto/FirebaseTokenDto.java
@@ -1,0 +1,14 @@
+package aiku_main.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class FirebaseTokenDto {
+    @NotNull
+    private String token;
+}

--- a/aiku/aiku-main/src/main/java/aiku_main/exception/FcmTokenDuplicateException.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/exception/FcmTokenDuplicateException.java
@@ -1,0 +1,20 @@
+package aiku_main.exception;
+
+import common.exception.BaseException;
+import common.response.status.BaseErrorCode;
+import common.response.status.StatusCode;
+
+public class FcmTokenDuplicateException extends BaseException {
+
+    public FcmTokenDuplicateException(StatusCode status, String errorMessage) {
+        super(status, errorMessage);
+    }
+
+    public FcmTokenDuplicateException(StatusCode status){
+        super(status, "토큰 중복 에러입니다.");
+    }
+
+    public FcmTokenDuplicateException() {
+        this(BaseErrorCode.DUPLICATED_FCM_TOKEN);
+    }
+}

--- a/aiku/aiku-main/src/main/java/aiku_main/exception/NoFcmTokenException.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/exception/NoFcmTokenException.java
@@ -1,0 +1,20 @@
+package aiku_main.exception;
+
+import common.exception.BaseException;
+import common.response.status.BaseErrorCode;
+import common.response.status.StatusCode;
+
+public class NoFcmTokenException extends BaseException {
+
+    public NoFcmTokenException(StatusCode status, String errorMessage) {
+        super(status, errorMessage);
+    }
+
+    public NoFcmTokenException(StatusCode status){
+        super(status, "토큰 중복 에러입니다.");
+    }
+
+    public NoFcmTokenException() {
+        this(BaseErrorCode.NO_FCM_TOKEN);
+    }
+}

--- a/aiku/aiku-main/src/main/java/aiku_main/service/MemberFirebaseService.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/service/MemberFirebaseService.java
@@ -1,0 +1,54 @@
+package aiku_main.service;
+
+import aiku_main.dto.FirebaseTokenDto;
+import aiku_main.dto.TermResDto;
+import aiku_main.exception.FcmTokenDuplicateException;
+import aiku_main.exception.MemberNotFoundException;
+import aiku_main.exception.NoFcmTokenException;
+import aiku_main.exception.NoSuchTermException;
+import aiku_main.repository.MemberRepository;
+import aiku_main.repository.TermRepository;
+import common.domain.Term;
+import common.domain.TermTitle;
+import common.domain.member.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class MemberFirebaseService {
+
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public Long saveToken(Long accessMemberId, FirebaseTokenDto firebaseTokenDto) {
+        Member member = memberRepository.findById(accessMemberId)
+                .orElseThrow(() -> new MemberNotFoundException());
+
+        if (!Objects.isNull(member.getFirebaseToken())) {
+            throw new FcmTokenDuplicateException();
+        }
+        member.updateFirebaseToken(firebaseTokenDto.getToken());
+
+        return member.getId();
+    }
+
+    @Transactional
+    public Long updateToken(Long accessMemberId, FirebaseTokenDto firebaseTokenDto) {
+        Member member = memberRepository.findById(accessMemberId)
+                .orElseThrow(() -> new MemberNotFoundException());
+
+        if (Objects.isNull(member.getFirebaseToken())) {
+            throw new NoFcmTokenException();
+        }
+        member.updateFirebaseToken(firebaseTokenDto.getToken());
+
+        return member.getId();
+    }
+}

--- a/aiku/aiku-main/src/test/java/aiku_main/integration_test/MemberFirebaseServiceTest.java
+++ b/aiku/aiku-main/src/test/java/aiku_main/integration_test/MemberFirebaseServiceTest.java
@@ -1,0 +1,111 @@
+package aiku_main.integration_test;
+
+import aiku_main.dto.FirebaseTokenDto;
+import aiku_main.exception.FcmTokenDuplicateException;
+import aiku_main.exception.MemberNotFoundException;
+import aiku_main.exception.NoFcmTokenException;
+import aiku_main.repository.MemberRepository;
+import aiku_main.service.MemberFirebaseService;
+import common.domain.member.Member;
+import common.domain.member.MemberProfileBackground;
+import common.domain.member.MemberProfileCharacter;
+import common.domain.member.MemberProfileType;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@Transactional
+@SpringBootTest(properties = "spring.config.location=classpath:application-test.yml")
+class MemberFirebaseServiceTest {
+
+    @Autowired
+    EntityManager em;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    MemberFirebaseService memberFirebaseService;
+
+    Member member;
+
+    FirebaseTokenDto originalFcm;
+    FirebaseTokenDto newFcm;
+
+    @BeforeEach
+    void setUp() {
+        member = Member.builder()
+                .kakaoId(123L)
+                .nickname("nickname1")
+                .password("password1")
+                .email("asdasd@gmail.com")
+                .build();
+
+        member.updateProfile(MemberProfileType.CHAR, "", MemberProfileCharacter.C01, MemberProfileBackground.BLUE);
+
+        member.updateAuth(true, true, false, true);
+
+        em.persist(member);
+
+        originalFcm = new FirebaseTokenDto("fcmToken1");
+        newFcm = new FirebaseTokenDto("fcmToken2");
+    }
+
+    @Test
+    void 멤버x_토큰저장_예외() {
+        Long id = member.getId() + 1;
+        Assertions.assertThrows(MemberNotFoundException.class, () -> {
+            memberFirebaseService.saveToken(id, originalFcm);
+        });
+    }
+
+    @Test
+    void 멤버x_토큰수정_예외() {
+        Long id = member.getId() + 1;
+        Assertions.assertThrows(MemberNotFoundException.class, () -> {
+            memberFirebaseService.updateToken(id, originalFcm);
+        });
+    }
+
+    @Test
+    void 토큰x_토큰저장_정상() {
+        memberFirebaseService.saveToken(member.getId(), originalFcm);
+
+        assertThat(member.getFirebaseToken()).isEqualTo("fcmToken1");
+    }
+
+    @Test
+    void 토큰o_토큰저장_예외() {
+        memberFirebaseService.saveToken(member.getId(), originalFcm);
+
+        Assertions.assertThrows(FcmTokenDuplicateException.class, () -> {
+            memberFirebaseService.saveToken(member.getId(), newFcm);
+        });
+    }
+
+    @Test
+    void 토큰o_토큰수정_정상() {
+        memberFirebaseService.saveToken(member.getId(), originalFcm);
+        memberFirebaseService.updateToken(member.getId(), newFcm);
+
+        assertThat(member.getFirebaseToken()).isEqualTo("fcmToken2");
+    }
+
+    @Test
+    void 토큰x_토큰수정_예() {
+        Assertions.assertThrows(NoFcmTokenException.class, () -> {
+            memberFirebaseService.updateToken(member.getId(), newFcm);
+        });
+    }
+}


### PR DESCRIPTION
## 관련 이슈 번호
<br />

- #52 
## 작업 사항
<br />

- 멤버 도메인 firebaseToken 필드 추가
- firebase 토큰을 저장하기 위한 컨트롤러, 서비스 로직 추가
- 테스트 코드 작성
## 기타 사항
<br />
