### PR TITLE
Kafka scheudule-close, schedule-arrival consume 로직 개발

### DIFF
--- a/aiku/aiku-common/src/main/java/common/domain/schedule/Schedule.java
+++ b/aiku/aiku-common/src/main/java/common/domain/schedule/Schedule.java
@@ -112,9 +112,8 @@ public class Schedule extends BaseTime {
         return false;
     }
 
-    public void close(){
-        this.scheduleStatus = TERM;
-        this.isAutoClose = false;
+    public void close(LocalDateTime scheduleCloseTime){
+        setTerm(scheduleCloseTime);
     }
 
     public void autoClose(List<ScheduleMember> notArriveScheduleMembers, LocalDateTime closeTime){
@@ -123,8 +122,8 @@ public class Schedule extends BaseTime {
                 scheduleMember.arrive(closeTime, -30);
             }
         });
-        this.scheduleTermTime = closeTime;
-        this.scheduleStatus = TERM;
+
+        setTerm(closeTime);
         this.isAutoClose = true;
     }
 

--- a/aiku/aiku-common/src/main/java/common/domain/schedule/Schedule.java
+++ b/aiku/aiku-common/src/main/java/common/domain/schedule/Schedule.java
@@ -112,6 +112,11 @@ public class Schedule extends BaseTime {
         return false;
     }
 
+    public void close(){
+        this.scheduleStatus = TERM;
+        this.isAutoClose = false;
+    }
+
     public void autoClose(List<ScheduleMember> notArriveScheduleMembers, LocalDateTime closeTime){
         notArriveScheduleMembers.forEach(scheduleMember -> {
             if(scheduleMember.getSchedule().getId().equals(id)){

--- a/aiku/aiku-common/src/main/java/common/kafka_message/KafkaTopic.java
+++ b/aiku/aiku-common/src/main/java/common/kafka_message/KafkaTopic.java
@@ -1,5 +1,5 @@
 package common.kafka_message;
 
 public enum KafkaTopic {
-    alarm
+    test, alarm
 }

--- a/aiku/aiku-common/src/main/java/common/kafka_message/ScheduleArrivalMessage.java
+++ b/aiku/aiku-common/src/main/java/common/kafka_message/ScheduleArrivalMessage.java
@@ -1,0 +1,20 @@
+package common.kafka_message;
+
+import common.domain.value_reference.MemberValue;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class ScheduleArrivalMessage {
+
+    private Long scheduleId;
+    private Long memberId;
+    private LocalDateTime arrivalTime;
+
+    public ScheduleArrivalMessage(Long scheduleId, MemberValue member, LocalDateTime arrivalTime) {
+        this.scheduleId = scheduleId;
+        this.memberId = member.getId();
+        this.arrivalTime = arrivalTime;
+    }
+}

--- a/aiku/aiku-common/src/main/java/common/kafka_message/ScheduleCloseMessage.java
+++ b/aiku/aiku-common/src/main/java/common/kafka_message/ScheduleCloseMessage.java
@@ -1,0 +1,17 @@
+package common.kafka_message;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PACKAGE)
+@AllArgsConstructor
+public class ScheduleCloseMessage {
+
+    private Long scheduleId;
+    private LocalDateTime scheduleCloseTime;
+}

--- a/aiku/aiku-main/src/main/java/aiku_main/application_event/event/ScheduleAutoCloseEvent.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/application_event/event/ScheduleAutoCloseEvent.java
@@ -1,10 +1,7 @@
 package aiku_main.application_event.event;
 
 import common.domain.schedule.Schedule;
-import common.domain.team.Team;
 import common.domain.value_reference.ScheduleValue;
-import common.domain.value_reference.TeamValue;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter

--- a/aiku/aiku-main/src/main/java/aiku_main/application_event/handler/ScheduleHandler.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/application_event/handler/ScheduleHandler.java
@@ -1,6 +1,7 @@
 package aiku_main.application_event.handler;
 
 import aiku_main.application_event.event.ScheduleAutoCloseEvent;
+import aiku_main.application_event.event.ScheduleCloseEvent;
 import aiku_main.application_event.event.ScheduleOpenEvent;
 import aiku_main.application_event.event.TeamExitEvent;
 import aiku_main.service.ScheduleService;
@@ -31,7 +32,7 @@ public class ScheduleHandler {
     @Order(1)
     @Async
     @EventListener
-    public void closeSchedule(ScheduleAutoCloseEvent event){
+    public void closeScheduleAuto(ScheduleAutoCloseEvent event){
         scheduleService.closeScheduleAuto(event.getSchedule().getId());
     }
 
@@ -52,4 +53,15 @@ public class ScheduleHandler {
         }
     }
 
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void processSchedulePoint(ScheduleCloseEvent event){
+        scheduleService.processScheduleResultPoint(event.getSchedule().getId());
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void analyzeScheduleArrivalResult(ScheduleCloseEvent event) {
+        scheduleService.analyzeScheduleArrivalResult(event.getSchedule().getId());
+    }
 }

--- a/aiku/aiku-main/src/main/java/aiku_main/kafka/KafkaConsumerService.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/kafka/KafkaConsumerService.java
@@ -36,7 +36,7 @@ public class KafkaConsumerService {
         } catch (JsonProcessingException e) {
             log.error("KafkaConsumerService.consumeScheduleClose에서 ScheduleCloseMessage파싱 오류가 발생하였습니다.", e);
         }
-        
+
         ack.acknowledge();
     }
 }

--- a/aiku/aiku-main/src/main/java/aiku_main/kafka/KafkaConsumerService.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/kafka/KafkaConsumerService.java
@@ -1,0 +1,24 @@
+package aiku_main.kafka;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class KafkaConsumerService {
+
+    @KafkaListener(topics = {"test"}, groupId = "test", concurrency = "1")
+    public void consumeTest(ConsumerRecord<String, String> data, Acknowledgment ack){
+        log.info("KafkaConsumerService Test : value = {}", data.value());
+        ack.acknowledge();
+    }
+
+    @KafkaListener(topics = {"schedule-close"}, groupId = "aiku-main", concurrency = "1")
+    public void consumeScheduleClose(ConsumerRecord<String, String> data, Acknowledgment ack){
+
+        ack.acknowledge();
+    }
+}

--- a/aiku/aiku-main/src/main/java/aiku_main/kafka/KafkaConsumerService.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/kafka/KafkaConsumerService.java
@@ -1,5 +1,7 @@
 package aiku_main.kafka;
 
+import aiku_main.service.ScheduleService;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -7,8 +9,11 @@ import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Service;
 
 @Slf4j
+@RequiredArgsConstructor
 @Service
 public class KafkaConsumerService {
+
+    private final ScheduleService scheduleService;
 
     @KafkaListener(topics = {"test"}, groupId = "test", concurrency = "1")
     public void consumeTest(ConsumerRecord<String, String> data, Acknowledgment ack){

--- a/aiku/aiku-main/src/main/java/aiku_main/kafka/KafkaConsumerService.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/kafka/KafkaConsumerService.java
@@ -1,6 +1,10 @@
 package aiku_main.kafka;
 
 import aiku_main.service.ScheduleService;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import common.kafka_message.ScheduleCloseMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -14,6 +18,7 @@ import org.springframework.stereotype.Service;
 public class KafkaConsumerService {
 
     private final ScheduleService scheduleService;
+    private final ObjectMapper objectMapper;
 
     @KafkaListener(topics = {"test"}, groupId = "test", concurrency = "1")
     public void consumeTest(ConsumerRecord<String, String> data, Acknowledgment ack){
@@ -23,7 +28,15 @@ public class KafkaConsumerService {
 
     @KafkaListener(topics = {"schedule-close"}, groupId = "aiku-main", concurrency = "1")
     public void consumeScheduleClose(ConsumerRecord<String, String> data, Acknowledgment ack){
-
+        try {
+            ScheduleCloseMessage scheduleCloseMessage = objectMapper.readValue(data.value(), ScheduleCloseMessage.class);
+            scheduleService.closeSchedule(scheduleCloseMessage.getScheduleId(), scheduleCloseMessage.getScheduleCloseTime());
+        } catch (JsonMappingException e) {
+            log.error("KafkaConsumerService.consumeScheduleClose에서 ScheduleCloseMessage파싱 오류가 발생하였습니다.", e);
+        } catch (JsonProcessingException e) {
+            log.error("KafkaConsumerService.consumeScheduleClose에서 ScheduleCloseMessage파싱 오류가 발생하였습니다.", e);
+        }
+        
         ack.acknowledge();
     }
 }

--- a/aiku/aiku-main/src/main/java/aiku_main/repository/ScheduleQueryRepositoryCustom.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/repository/ScheduleQueryRepositoryCustom.java
@@ -14,12 +14,12 @@ import java.util.Optional;
 
 public interface ScheduleQueryRepositoryCustom {
 
-    Optional<Schedule> findScheduleWithNotArriveScheduleMember(Long scheduleId);
     List<Schedule> findMemberScheduleInTeamWithMember(Long memberId, Long teamId);
 
     Optional<ScheduleMember> findScheduleMember(Long memberId, Long scheduleId);
     Optional<ScheduleMember> findScheduleMemberWithMemberById(Long scheduleMemberId);
     Optional<ScheduleMember> findNextScheduleOwnerWithMember(Long scheduleId, Long prevOwnerScheduleMemberId);
+    List<ScheduleMember> findNotArriveScheduleMember(Long scheduleId);
     List<ScheduleMember> findPaidEarlyScheduleMemberWithMember(Long scheduleId);
     List<ScheduleMember> findPaidLateScheduleMemberWithMember(Long scheduleId);
     List<ScheduleMember> findWaitScheduleMemberWithScheduleInTeam(Long memberId, Long teamId);

--- a/aiku/aiku-main/src/main/java/aiku_main/repository/ScheduleQueryRepositoryCustomImpl.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/repository/ScheduleQueryRepositoryCustomImpl.java
@@ -28,15 +28,12 @@ public class ScheduleQueryRepositoryCustomImpl implements ScheduleQueryRepositor
     private final JPAQueryFactory query;
 
     @Override
-    public Optional<Schedule> findScheduleWithNotArriveScheduleMember(Long scheduleId) {
-        Schedule findSchedule = query.selectFrom(schedule)
-                .join(schedule.scheduleMembers, scheduleMember).fetchJoin()
-                .where(schedule.id.eq(scheduleId),
+    public List<ScheduleMember> findNotArriveScheduleMember(Long scheduleId) {
+        return query.selectFrom(scheduleMember)
+                .where(scheduleMember.schedule.id.eq(scheduleId),
                         scheduleMember.arrivalTime.isNull(),
                         scheduleMember.status.eq(ALIVE))
-                .fetchOne();
-
-        return Optional.ofNullable(findSchedule);
+                .fetch();
     }
 
     @Override

--- a/aiku/aiku-main/src/main/java/aiku_main/service/ScheduleService.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/service/ScheduleService.java
@@ -194,6 +194,14 @@ public class ScheduleService {
     }
 
     @Transactional
+    public void arriveSchedule(Long scheduleId, Long memberId, LocalDateTime arrivalTime){
+        Schedule schedule = findScheduleById(scheduleId);
+        ScheduleMember scheduleMember = scheduleQueryRepository.findScheduleMember(memberId, scheduleId).orElseThrow();
+
+        schedule.arriveScheduleMember(scheduleMember, arrivalTime);
+    }
+
+    @Transactional
     public void closeSchedule(Long scheduleId, LocalDateTime scheduleCloseTime){
         Schedule schedule = findScheduleById(scheduleId);
         schedule.close(scheduleCloseTime);

--- a/aiku/aiku-main/src/main/java/aiku_main/service/ScheduleService.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/service/ScheduleService.java
@@ -291,10 +291,11 @@ public class ScheduleService {
             return;
         }
 
-        Schedule schedule = scheduleQueryRepository.findScheduleWithNotArriveScheduleMember(scheduleId).orElseThrow();
+        Schedule schedule = findScheduleById(scheduleId);
+        List<ScheduleMember> notArriveScheduleMembers = scheduleQueryRepository.findNotArriveScheduleMember(scheduleId);
 
         LocalDateTime autoCloseTime = schedule.getScheduleTime().plusMinutes(30);
-        schedule.autoClose(schedule.getScheduleMembers(), autoCloseTime);
+        schedule.autoClose(notArriveScheduleMembers, autoCloseTime);
 
         sendMessageToScheduleMembers(schedule, null, null, AlarmMessageType.SCHEDULE_AUTO_CLOSE);
     }

--- a/aiku/aiku-main/src/main/java/aiku_main/service/ScheduleService.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/service/ScheduleService.java
@@ -194,9 +194,9 @@ public class ScheduleService {
     }
 
     @Transactional
-    public void closeSchedule(Long scheduleId){
+    public void closeSchedule(Long scheduleId, LocalDateTime scheduleCloseTime){
         Schedule schedule = findScheduleById(scheduleId);
-        schedule.close();
+        schedule.close(scheduleCloseTime);
 
         scheduleEventPublisher.publishScheduleCloseEvent(schedule);
     }

--- a/aiku/aiku-main/src/main/java/aiku_main/service/ScheduleService.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/service/ScheduleService.java
@@ -193,6 +193,14 @@ public class ScheduleService {
         }
     }
 
+    @Transactional
+    public void closeSchedule(Long scheduleId){
+        Schedule schedule = findScheduleById(scheduleId);
+        schedule.close();
+
+        scheduleEventPublisher.publishScheduleCloseEvent(schedule);
+    }
+
     public ScheduleDetailResDto getScheduleDetail(Member member, Long teamId, Long scheduleId) {
         //검증 메서드
         Schedule schedule = findScheduleById(scheduleId);

--- a/aiku/aiku-main/src/main/resources/application.yml
+++ b/aiku/aiku-main/src/main/resources/application.yml
@@ -17,6 +17,8 @@ spring:
         default_batch_fetch_size: 100
   kafka:
     bootstrap-servers: ${KAFKA_SERVER_URL}
+    listener:
+      ack-mode: manual  # 수동 AckMode 설정
     consumer:
       auto-offset-reset: latest
       value-deserializer: org.apache.kafka.common.serialization.StringDeserializer

--- a/aiku/aiku-main/src/test/java/aiku_main/integration_test/BettingServiceIntegrationTest.java
+++ b/aiku/aiku-main/src/test/java/aiku_main/integration_test/BettingServiceIntegrationTest.java
@@ -83,8 +83,8 @@ class BettingServiceIntegrationTest {
 
     @AfterEach
     void afterEach(){
-        memberRepository.deleteAll();
         scheduleQueryRepository.deleteAll();
+        memberRepository.deleteAll();
     }
 
     @Test
@@ -162,9 +162,6 @@ class BettingServiceIntegrationTest {
         //when
         bettingService.cancelBetting(member1, schedule1.getId(), betting.getId());
 
-        em.flush();
-        em.clear();
-
         //then
         Betting findBetting = bettingQueryRepository.findById(betting.getId()).orElseThrow();
         assertThat(findBetting.getBettingStatus()).isEqualTo(WAIT);
@@ -221,7 +218,7 @@ class BettingServiceIntegrationTest {
         em.persist(betting);
 
         //when
-        bettingService.exitSchedule_deleteBettingForBettor(member1.getId(), bettor.getId(), schedule1.getId());em.clear();
+        bettingService.exitSchedule_deleteBettingForBettor(member1.getId(), bettor.getId(), schedule1.getId());
 
         //then
         Betting findBetting = bettingQueryRepository.findById(betting.getId()).orElse(null);
@@ -319,7 +316,7 @@ class BettingServiceIntegrationTest {
         List<ScheduleMember> scheduleMembers = schedule1.getScheduleMembers();
         schedule1.arriveScheduleMember(scheduleMembers.get(0), schedule1.getScheduleTime().plusMinutes(30));
         schedule1.arriveScheduleMember(scheduleMembers.get(1), LocalDateTime.now());
-        schedule1.arriveScheduleMember(scheduleMembers.get(2), schedule1.getScheduleTime().plusMinutes(30));em.clear();
+        schedule1.arriveScheduleMember(scheduleMembers.get(2), schedule1.getScheduleTime().plusMinutes(30));
 
         //when
         bettingService.processBettingResult(schedule1.getId());

--- a/aiku/aiku-main/src/test/java/aiku_main/integration_test/BettingServiceIntegrationTest.java
+++ b/aiku/aiku-main/src/test/java/aiku_main/integration_test/BettingServiceIntegrationTest.java
@@ -93,9 +93,6 @@ class BettingServiceIntegrationTest {
         BettingAddDto bettingDto = new BettingAddDto(member2.getId(), 0);
         Long bettingId = bettingService.addBetting(member1, schedule1.getId(), bettingDto);
 
-        em.flush();
-        em.clear();
-
         //then
         Betting betting = bettingQueryRepository.findById(bettingId).orElse(null);
         ScheduleMember bettor = scheduleQueryRepository.findScheduleMember(member1.getId(), schedule1.getId()).orElse(null);
@@ -139,9 +136,6 @@ class BettingServiceIntegrationTest {
         Betting betting = Betting.create(new ScheduleMemberValue(bettor), new ScheduleMemberValue(betee), 0);
         em.persist(betting);
 
-        em.flush();
-        em.clear();
-
         //when
         BettingAddDto bettingDto = new BettingAddDto(member2.getId(), 0);
         assertThatThrownBy(() -> bettingService.addBetting(member1, schedule1.getId(), bettingDto)).isInstanceOf(BettingException.class);
@@ -165,9 +159,6 @@ class BettingServiceIntegrationTest {
         Betting betting = Betting.create(new ScheduleMemberValue(bettor), new ScheduleMemberValue(betee), 100);
         em.persist(betting);
 
-        em.flush();
-        em.clear();
-
         //when
         bettingService.cancelBetting(member1, schedule1.getId(), betting.getId());
 
@@ -189,9 +180,6 @@ class BettingServiceIntegrationTest {
         Betting betting = Betting.create(new ScheduleMemberValue(bettor), new ScheduleMemberValue(betee), 100);
         em.persist(betting);
 
-        em.flush();
-        em.clear();
-
         //when
         bettingService.cancelBetting(member1, schedule1.getId(), betting.getId());
         assertThatThrownBy(() -> bettingService.cancelBetting(member1, schedule1.getId(), betting.getId())).isInstanceOf(BettingException.class);
@@ -206,9 +194,6 @@ class BettingServiceIntegrationTest {
         Betting betting = Betting.create(new ScheduleMemberValue(bettor), new ScheduleMemberValue(betee), 100);
         em.persist(betting);
 
-        em.flush();
-        em.clear();
-
         //when
         assertThatThrownBy(() -> bettingService.cancelBetting(member2, schedule1.getId(), betting.getId())).isInstanceOf(BettingException.class);
     }
@@ -221,9 +206,6 @@ class BettingServiceIntegrationTest {
 
         Betting betting = Betting.create(new ScheduleMemberValue(bettor), new ScheduleMemberValue(betee), 100);
         em.persist(betting);
-
-        em.flush();
-        em.clear();
 
         //when
         assertThatThrownBy(() -> bettingService.cancelBetting(noScheduleMember, schedule1.getId(), betting.getId())).isInstanceOf(ScheduleException.class);
@@ -238,13 +220,8 @@ class BettingServiceIntegrationTest {
         Betting betting = Betting.create(new ScheduleMemberValue(bettor), new ScheduleMemberValue(betee), 100);
         em.persist(betting);
 
-        em.flush();
-        em.clear();
-
         //when
-        bettingService.exitSchedule_deleteBettingForBettor(member1.getId(), bettor.getId(), schedule1.getId());
-        em.flush();
-        em.clear();
+        bettingService.exitSchedule_deleteBettingForBettor(member1.getId(), bettor.getId(), schedule1.getId());em.clear();
 
         //then
         Betting findBetting = bettingQueryRepository.findById(betting.getId()).orElse(null);
@@ -261,13 +238,8 @@ class BettingServiceIntegrationTest {
         Betting betting = Betting.create(new ScheduleMemberValue(bettor), new ScheduleMemberValue(betee), 100);
         em.persist(betting);
 
-        em.flush();
-        em.clear();
-
         //when
         bettingService.exitSchedule_deleteBettingForBettor(member2.getId(), bettor.getId(), schedule1.getId());
-        em.flush();
-        em.clear();
 
         //then
         Betting findBetting = bettingQueryRepository.findById(betting.getId()).orElse(null);
@@ -292,13 +264,8 @@ class BettingServiceIntegrationTest {
         schedule1.arriveScheduleMember(scheduleMembers.get(1), LocalDateTime.now());
         schedule1.arriveScheduleMember(scheduleMembers.get(2), LocalDateTime.now());
 
-        em.flush();
-        em.clear();
-
         //when
         bettingService.processBettingResult(schedule1.getId());
-        em.flush();
-        em.clear();
 
         //then
         List<Betting> bettings = bettingQueryRepository.findBettingsInSchedule(schedule1.getId(), TERM);
@@ -325,13 +292,8 @@ class BettingServiceIntegrationTest {
         schedule1.arriveScheduleMember(scheduleMembers.get(1), LocalDateTime.now());
         schedule1.arriveScheduleMember(scheduleMembers.get(2), LocalDateTime.now().plusMinutes(30));
 
-        em.flush();
-        em.clear();
-
         //when
         bettingService.processBettingResult(schedule1.getId());
-        em.flush();
-        em.clear();
 
         //then
         List<Betting> bettings = bettingQueryRepository.findBettingsInSchedule(schedule1.getId(), TERM);
@@ -357,15 +319,10 @@ class BettingServiceIntegrationTest {
         List<ScheduleMember> scheduleMembers = schedule1.getScheduleMembers();
         schedule1.arriveScheduleMember(scheduleMembers.get(0), schedule1.getScheduleTime().plusMinutes(30));
         schedule1.arriveScheduleMember(scheduleMembers.get(1), LocalDateTime.now());
-        schedule1.arriveScheduleMember(scheduleMembers.get(2), schedule1.getScheduleTime().plusMinutes(30));
-
-        em.flush();
-        em.clear();
+        schedule1.arriveScheduleMember(scheduleMembers.get(2), schedule1.getScheduleTime().plusMinutes(30));em.clear();
 
         //when
         bettingService.processBettingResult(schedule1.getId());
-        em.flush();
-        em.clear();
 
         //then
         List<Betting> bettings = bettingQueryRepository.findBettingsInSchedule(schedule1.getId(), TERM);
@@ -390,13 +347,8 @@ class BettingServiceIntegrationTest {
         em.persist(betting2);
         em.persist(betting3);
 
-        em.flush();
-        em.clear();
-
         //when
         bettingService.analyzeScheduleBettingResult(schedule1.getId());
-        em.flush();
-        em.clear();
 
         //then
         Schedule findSchedule = scheduleQueryRepository.findById(schedule1.getId()).orElse(null);

--- a/aiku/aiku-main/src/test/java/aiku_main/integration_test/ScheduleServiceIntegrationTest.java
+++ b/aiku/aiku-main/src/test/java/aiku_main/integration_test/ScheduleServiceIntegrationTest.java
@@ -368,7 +368,7 @@ public class ScheduleServiceIntegrationTest {
         em.persist(schedule);
 
         //when
-        schedule.close();
+        schedule.close(LocalDateTime.now());
 
         //then
         Schedule findSchedule = scheduleQueryRepository.findById(schedule.getId()).orElse(null);

--- a/aiku/aiku-main/src/test/java/aiku_main/integration_test/ScheduleServiceIntegrationTest.java
+++ b/aiku/aiku-main/src/test/java/aiku_main/integration_test/ScheduleServiceIntegrationTest.java
@@ -377,6 +377,25 @@ public class ScheduleServiceIntegrationTest {
     }
 
     @Test
+    void 스케줄_도착() {
+        //given
+        Team team = Team.create(member1, "team1");
+        em.persist(team);
+
+        Schedule schedule = createSchedule(member1, team, 100);
+        em.persist(schedule);
+
+        //when
+        LocalDateTime arrivalTime = LocalDateTime.now();
+        scheduleService.arriveSchedule(schedule.getId(), member1.getId(), arrivalTime);
+
+        //then
+        ScheduleMember scheduleMember = scheduleQueryRepository.findScheduleMember(member1.getId(), schedule.getId()).orElse(null);
+        assertThat(scheduleMember).isNotNull();
+        assertThat(scheduleMember.getArrivalTimeDiff()).isEqualTo(Duration.between(arrivalTime, schedule.getScheduleTime()).toMinutes());
+    }
+
+    @Test
     void 스케줄_상세_조회() {
         //given
         Team team = Team.create(member1, "team1");

--- a/aiku/aiku-main/src/test/java/aiku_main/integration_test/ScheduleServiceIntegrationTest.java
+++ b/aiku/aiku-main/src/test/java/aiku_main/integration_test/ScheduleServiceIntegrationTest.java
@@ -20,6 +20,8 @@ import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
@@ -39,6 +41,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 @SpringBootTest
 public class ScheduleServiceIntegrationTest {
 
+    private static final Logger log = LoggerFactory.getLogger(ScheduleServiceIntegrationTest.class);
     @Autowired
     EntityManager em;
     @Autowired
@@ -85,9 +88,6 @@ public class ScheduleServiceIntegrationTest {
                 new LocationDto("lo1", 1.0, 1.0), LocalDateTime.now().plusHours(1), 0);
         Long scheduleId = scheduleService.addSchedule(member1, team.getId(), scheduleDto);
 
-        em.flush();
-        em.clear();
-
         //then
         Schedule schedule = scheduleQueryRepository.findById(scheduleId).orElse(null);
         assertThat(schedule).isNotNull();
@@ -117,16 +117,10 @@ public class ScheduleServiceIntegrationTest {
         Schedule schedule = createSchedule(member1, team, 0);
         em.persist(schedule);
 
-        em.flush();
-        em.clear();
-
         //when
         ScheduleUpdateDto scheduleDto = new ScheduleUpdateDto("new",
                 new LocationDto("new", 2.0, 2.0), LocalDateTime.now().plusHours(2));
         scheduleService.updateSchedule(member1, schedule.getId(), scheduleDto);
-
-        em.flush();
-        em.clear();
 
         //then
         Schedule findSchedule = scheduleQueryRepository.findById(schedule.getId()).get();
@@ -145,9 +139,6 @@ public class ScheduleServiceIntegrationTest {
         schedule.addScheduleMember(member2, false, 0);
         em.persist(schedule);
 
-        em.flush();
-        em.clear();
-
         //when
         ScheduleUpdateDto scheduleDto = new ScheduleUpdateDto("new",
                 new LocationDto("new", 2.0, 2.0), LocalDateTime.now().plusHours(2));
@@ -163,9 +154,6 @@ public class ScheduleServiceIntegrationTest {
         Schedule schedule = Schedule.create(member1, null, "sche1", LocalDateTime.now().plusMinutes(30),
                 new Location("loc1", 1.0, 1.0), 0);
         em.persist(schedule);
-
-        em.flush();
-        em.clear();
 
         //when
         ScheduleUpdateDto scheduleDto = new ScheduleUpdateDto("new",
@@ -183,15 +171,9 @@ public class ScheduleServiceIntegrationTest {
         Schedule schedule = createSchedule(member1, team, 100);
         em.persist(schedule);
 
-        em.flush();
-        em.clear();
-
         //when
         ScheduleEnterDto enterDto = new ScheduleEnterDto(0);
         Long scheduleId = scheduleService.enterSchedule(member2, team.getId(), schedule.getId(), enterDto);
-
-        em.flush();
-        em.clear();
 
         //then
         Schedule findSchedule = scheduleQueryRepository.findById(scheduleId).orElse(null);
@@ -216,9 +198,6 @@ public class ScheduleServiceIntegrationTest {
         schedule.addScheduleMember(member2, false, 0);
         em.persist(schedule);
 
-        em.flush();
-        em.clear();
-
         //when
         ScheduleEnterDto enterDto = new ScheduleEnterDto(0);
         assertThatThrownBy(() -> scheduleService.enterSchedule(member2, team.getId(), schedule.getId(), enterDto)).isInstanceOf(ScheduleException.class);
@@ -232,9 +211,6 @@ public class ScheduleServiceIntegrationTest {
 
         Schedule schedule = createSchedule(member1, team, 100);
         em.persist(schedule);
-
-        em.flush();
-        em.clear();
 
         //when
         ScheduleEnterDto enterDto = new ScheduleEnterDto(0);
@@ -251,9 +227,6 @@ public class ScheduleServiceIntegrationTest {
         Schedule schedule = createSchedule(member1, team, 100);
         schedule.setRun();
         em.persist(schedule);
-
-        em.flush();
-        em.clear();
 
         //when
         ScheduleEnterDto enterDto = new ScheduleEnterDto(0);
@@ -273,14 +246,8 @@ public class ScheduleServiceIntegrationTest {
         schedule.addScheduleMember(member3, false, 100);
         em.persist(schedule);
 
-        em.flush();
-        em.clear();
-
         //when
         scheduleService.exitSchedule(member2, team.getId(), schedule.getId());
-
-        em.flush();
-        em.clear();
 
         //then
         Schedule findSchedule = scheduleQueryRepository.findById(schedule.getId()).orElse(null);
@@ -309,9 +276,6 @@ public class ScheduleServiceIntegrationTest {
         Schedule schedule = createSchedule(member1, team, 100);
         em.persist(schedule);
 
-        em.flush();
-        em.clear();
-
         //when
         assertThatThrownBy(() -> scheduleService.exitSchedule(member2, team.getId(), schedule.getId())).isInstanceOf(ScheduleException.class);
     }
@@ -328,8 +292,6 @@ public class ScheduleServiceIntegrationTest {
         em.persist(schedule);
 
         scheduleService.exitSchedule(member2, team.getId(), schedule.getId());
-        em.flush();
-        em.clear();
 
         //when
         assertThatThrownBy(() -> scheduleService.exitSchedule(member2, team.getId(), schedule.getId())).isInstanceOf(ScheduleException.class);
@@ -344,14 +306,8 @@ public class ScheduleServiceIntegrationTest {
         Schedule schedule = createSchedule(member1, team, 100);
         em.persist(schedule);
 
-        em.flush();
-        em.clear();
-
         //when
         scheduleService.exitSchedule(member1, team.getId(), schedule.getId());
-
-        em.flush();
-        em.clear();
 
         //then
         Schedule findSchedule = scheduleQueryRepository.findById(schedule.getId()).orElse(null);
@@ -371,17 +327,10 @@ public class ScheduleServiceIntegrationTest {
 
         Schedule schedule = createSchedule(member1, team, 0);
         schedule.addScheduleMember(member2, false, 0);
-
         em.persist(schedule);
-
-        em.flush();
-        em.clear();
 
         //when
         scheduleService.exitSchedule(member1, team.getId(), schedule.getId());
-
-        em.flush();
-        em.clear();
 
         //then
         Schedule findSchedule = scheduleQueryRepository.findById(schedule.getId()).orElse(null);
@@ -403,11 +352,7 @@ public class ScheduleServiceIntegrationTest {
         Schedule schedule = createSchedule(member1, team, 0);
         schedule.setTerm(LocalDateTime.now());
         schedule.addScheduleMember(member2, false, 0);
-
         em.persist(schedule);
-
-        em.flush();
-        em.clear();
 
         //when
         assertThatThrownBy(() -> scheduleService.exitSchedule(member1, team.getId(), schedule.getId())).isInstanceOf(ScheduleException.class);
@@ -445,14 +390,8 @@ public class ScheduleServiceIntegrationTest {
         schedule.addScheduleMember(member3, false, 100);
         em.persist(schedule);
 
-        em.flush();
-        em.clear();
-
         //when
         ScheduleDetailResDto resultDto = scheduleService.getScheduleDetail(member1, team.getId(), schedule.getId());
-
-        em.flush();
-        em.clear();
 
         //then
         assertThat(resultDto.getScheduleId()).isEqualTo(schedule.getId());
@@ -475,9 +414,6 @@ public class ScheduleServiceIntegrationTest {
         schedule.addScheduleMember(member2, false, 0);
         schedule.addScheduleMember(member3, false, 100);
         em.persist(schedule);
-
-        em.flush();
-        em.clear();
 
         //when
         assertThatThrownBy(() -> scheduleService.getScheduleDetail(member4, team.getId(), schedule.getId())).isInstanceOf(ScheduleException.class);
@@ -504,14 +440,8 @@ public class ScheduleServiceIntegrationTest {
         Schedule schedule3 = createSchedule(member3, team, 100);
         em.persist(schedule3);
 
-        em.flush();
-        em.clear();
-
         //when
         TeamScheduleListResDto result = scheduleService.getTeamScheduleList(member1, team.getId(), new SearchDateCond(), 1);
-
-        em.flush();
-        em.clear();
 
         //then
         assertThat(result.getRunSchedule()).isEqualTo(1);
@@ -553,14 +483,8 @@ public class ScheduleServiceIntegrationTest {
         Schedule schedule3 = createSchedule(member3, team, 100);
         em.persist(schedule3);
 
-        em.flush();
-        em.clear();
-
         //when
         TeamScheduleListResDto result = scheduleService.getTeamScheduleList(member1, team.getId(), new SearchDateCond(startDate, endDate), 1);
-
-        em.flush();
-        em.clear();
 
         //then
         assertThat(result.getRunSchedule()).isEqualTo(0);
@@ -594,9 +518,6 @@ public class ScheduleServiceIntegrationTest {
         Schedule scheduleB1 = createSchedule(member1, teamB, 0);
         scheduleB1.setRun();
         em.persist(scheduleB1);
-
-        em.flush();
-        em.clear();
 
         //when
         MemberScheduleListResDto result = scheduleService.getMemberScheduleList(member1, new SearchDateCond(), 1);
@@ -640,9 +561,6 @@ public class ScheduleServiceIntegrationTest {
         Schedule scheduleB2 = createSchedule(member1, teamB, 0);
         em.persist(scheduleB2);
 
-        em.flush();
-        em.clear();
-
         //when
         MemberScheduleListResDto result = scheduleService.getMemberScheduleList(member1, new SearchDateCond(startDate, null), 1);
 
@@ -682,9 +600,6 @@ public class ScheduleServiceIntegrationTest {
         Schedule scheduleB1 = createSchedule(member1, teamB, 100);
         em.persist(scheduleB1);
 
-        em.flush();
-        em.clear();
-
         //when
         scheduleService.exitAllScheduleInTeam(member1.getId(), team.getId());
 
@@ -703,7 +618,7 @@ public class ScheduleServiceIntegrationTest {
         team.addTeamMember(member3);
         em.persist(team);
 
-        Schedule schedule1 = createSchedule(member1, team, 0);
+        Schedule schedule1 = createSchedule(member1,  team, 0);
         schedule1.addScheduleMember(member2, false, 0);
         schedule1.addScheduleMember(member3, false, 0);
         em.persist(schedule1);
@@ -711,14 +626,8 @@ public class ScheduleServiceIntegrationTest {
         LocalDateTime arrivalTime = LocalDateTime.now();
         schedule1.arriveScheduleMember(schedule1.getScheduleMembers().get(0), arrivalTime);
 
-        em.flush();
-        em.clear();
-
         //when
         scheduleService.closeScheduleAuto(schedule1.getId());
-
-        em.flush();
-        em.clear();
 
         //then
         Schedule findSchedule = scheduleQueryRepository.findById(schedule1.getId()).orElse(null);
@@ -727,7 +636,7 @@ public class ScheduleServiceIntegrationTest {
 
         List<ScheduleMember> scheduleMembers = findSchedule.getScheduleMembers();
         assertThat(scheduleMembers).extracting("arrivalTimeDiff")
-                .contains(-30, -30, (int) Duration.between(arrivalTime, schedule1.getScheduleTime()).toMinutes());
+                .contains(-30, -30, (int) Duration.between(schedule1.getScheduleTime(), arrivalTime).toMinutes());
     }
 
     @Test
@@ -746,14 +655,8 @@ public class ScheduleServiceIntegrationTest {
         schedule1.arriveScheduleMember(schedule1.getScheduleMembers().get(1), arrivalTime);
         schedule1.setTerm(LocalDateTime.now());
 
-        em.flush();
-        em.clear();
-
         //when
         scheduleService.closeScheduleAuto(schedule1.getId());
-
-        em.flush();
-        em.clear();
 
         //then
         Schedule findSchedule = scheduleQueryRepository.findById(schedule1.getId()).orElse(null);
@@ -783,14 +686,8 @@ public class ScheduleServiceIntegrationTest {
         schedule1.arriveScheduleMember(schedule1.getScheduleMembers().get(2), arrivalTime);
         schedule1.setTerm(LocalDateTime.now());
 
-        em.flush();
-        em.clear();
-
         //when
         scheduleService.processScheduleResultPoint(schedule1.getId());
-
-        em.flush();
-        em.clear();
 
         //then
         Schedule findSchedule = scheduleQueryRepository.findById(schedule1.getId()).orElse(null);
@@ -818,14 +715,8 @@ public class ScheduleServiceIntegrationTest {
         schedule1.arriveScheduleMember(schedule1.getScheduleMembers().get(2), arrivalTime);
         schedule1.setTerm(LocalDateTime.now());
 
-        em.flush();
-        em.clear();
-
         //when
         scheduleService.processScheduleResultPoint(schedule1.getId());
-
-        em.flush();
-        em.clear();
 
         //then
         Schedule findSchedule = scheduleQueryRepository.findById(schedule1.getId()).orElse(null);
@@ -853,14 +744,8 @@ public class ScheduleServiceIntegrationTest {
         schedule1.arriveScheduleMember(schedule1.getScheduleMembers().get(2), arrivalTime);
         schedule1.setTerm(LocalDateTime.now());
 
-        em.flush();
-        em.clear();
-
         //when
         scheduleService.processScheduleResultPoint(schedule1.getId());
-
-        em.flush();
-        em.clear();
 
         //then
         Schedule findSchedule = scheduleQueryRepository.findById(schedule1.getId()).orElse(null);
@@ -888,13 +773,8 @@ public class ScheduleServiceIntegrationTest {
         schedule1.arriveScheduleMember(schedule1.getScheduleMembers().get(2), arrivalTime.plusHours(3));
         schedule1.setTerm(LocalDateTime.now());
 
-        em.flush();
-        em.clear();
-
         //when
         scheduleService.analyzeScheduleArrivalResult(schedule1.getId());
-        em.flush();
-        em.clear();
 
         //then
         Schedule findSchedule = scheduleQueryRepository.findById(schedule1.getId()).orElse(null);

--- a/aiku/aiku-main/src/test/java/aiku_main/integration_test/ScheduleServiceIntegrationTest.java
+++ b/aiku/aiku-main/src/test/java/aiku_main/integration_test/ScheduleServiceIntegrationTest.java
@@ -414,6 +414,24 @@ public class ScheduleServiceIntegrationTest {
     }
 
     @Test
+    void 스케줄_종료(){
+        //given
+        Team team = Team.create(member1, "team1");
+        em.persist(team);
+
+        Schedule schedule = createSchedule(member1, team, 100);
+        em.persist(schedule);
+
+        //when
+        schedule.close();
+
+        //then
+        Schedule findSchedule = scheduleQueryRepository.findById(schedule.getId()).orElse(null);
+        assertThat(findSchedule).isNotNull();
+        assertThat(findSchedule.getScheduleStatus()).isEqualTo(ExecStatus.TERM);
+    }
+
+    @Test
     void 스케줄_상세_조회() {
         //given
         Team team = Team.create(member1, "team1");

--- a/aiku/aiku-main/src/test/java/aiku_main/integration_test/ScheduleServiceIntegrationTest.java
+++ b/aiku/aiku-main/src/test/java/aiku_main/integration_test/ScheduleServiceIntegrationTest.java
@@ -625,9 +625,12 @@ public class ScheduleServiceIntegrationTest {
 
         LocalDateTime arrivalTime = LocalDateTime.now();
         schedule1.arriveScheduleMember(schedule1.getScheduleMembers().get(0), arrivalTime);
-
+        em.flush();
+        em.clear();
         //when
+        log.info("시작");
         scheduleService.closeScheduleAuto(schedule1.getId());
+        log.info("끝");
 
         //then
         Schedule findSchedule = scheduleQueryRepository.findById(schedule1.getId()).orElse(null);
@@ -636,7 +639,7 @@ public class ScheduleServiceIntegrationTest {
 
         List<ScheduleMember> scheduleMembers = findSchedule.getScheduleMembers();
         assertThat(scheduleMembers).extracting("arrivalTimeDiff")
-                .contains(-30, -30, (int) Duration.between(schedule1.getScheduleTime(), arrivalTime).toMinutes());
+                .contains(-30, -30, (int) Duration.between(arrivalTime, schedule1.getScheduleTime()).toMinutes());
     }
 
     @Test

--- a/aiku/aiku-main/src/test/java/aiku_main/kafka/KafkaConsumerServiceTest.java
+++ b/aiku/aiku-main/src/test/java/aiku_main/kafka/KafkaConsumerServiceTest.java
@@ -1,0 +1,23 @@
+package aiku_main.kafka;
+
+import common.kafka_message.KafkaTopic;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class KafkaConsumerServiceTest {
+
+    @Autowired
+    KafkaProducerService kafkaProducerService;
+
+    @Test
+    void consumeTest() throws InterruptedException {
+        //given
+        String message = "testMessage";
+        kafkaProducerService.sendMessage(KafkaTopic.test, message);
+
+        //given
+        Thread.sleep(5000);
+    }
+}

--- a/aiku/aiku-main/src/test/resources/application.yml
+++ b/aiku/aiku-main/src/test/resources/application.yml
@@ -19,6 +19,8 @@ spring:
         format_sql: true # 하이버네이트 기본 SQL 포맷팅 옵션
   kafka:
     bootstrap-servers: ${KAFKA_SERVER_URL}
+    listener:
+      ack-mode: manual  # 수동 AckMode 설정
     consumer:
       auto-offset-reset: latest
       value-deserializer: org.apache.kafka.common.serialization.StringDeserializer


### PR DESCRIPTION
## 관련 이슈 번호

- #56 

<br />

## 작업 사항

- schedule-close 메세지 consume시 스케줄 종료 처리, ScheduleCloseEvent publish 로직 개발
- schedule-arrival 메세지 consume시 스케줄 멤버 도착 처리
- 개발 기능 통합 테스트
- 공통 KafkaConsumerService 클래스 개발 및 테스트

<br />

## 기타 사항

- 후에 테스트 카프카 서버 분리 or 테스트 전용 토픽을 생성해야함.

<br />
