### PR TITLE
Access-Member-Id헤더로 요청 멤버 정보 처리 로직 추가

### DIFF
--- a/aiku/aiku-main/src/main/java/aiku_main/controller/BettingController.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/controller/BettingController.java
@@ -16,18 +16,20 @@ public class BettingController {
     private final BettingService bettingService;
 
     @PostMapping
-    public BaseResponse<BaseResultDto> addBetting(@PathVariable Long scheduleId,
+    public BaseResponse<BaseResultDto> addBetting(@RequestHeader(name = "Access-Member-Id") Long memberId,
+                                                  @PathVariable Long scheduleId,
                                                   @RequestBody @Valid BettingAddDto bettingDto){
-        Long resultId = bettingService.addBetting(null, scheduleId, bettingDto);
+        Long resultId = bettingService.addBetting(memberId, scheduleId, bettingDto);
 
         return BaseResponse.getSimpleRes(resultId);
     }
 
     @PostMapping("/{bettingId}")
-    public BaseResponse<BaseResultDto> cancelBetting(@PathVariable Long scheduleId,
-                                                  @PathVariable Long bettingId,
-                                                  @RequestBody BettingAddDto bettingDto){
-        Long resultId = bettingService.cancelBetting(null, scheduleId, bettingId);
+    public BaseResponse<BaseResultDto> cancelBetting(@RequestHeader(name = "Access-Member-Id") Long memberId,
+                                                     @PathVariable Long scheduleId,
+                                                     @PathVariable Long bettingId,
+                                                     @RequestBody BettingAddDto bettingDto){
+        Long resultId = bettingService.cancelBetting(memberId, scheduleId, bettingId);
 
         return BaseResponse.getSimpleRes(resultId);
     }

--- a/aiku/aiku-main/src/main/java/aiku_main/controller/ScheduleController.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/controller/ScheduleController.java
@@ -18,76 +18,85 @@ public class ScheduleController {
     private final ScheduleService scheduleService;
 
     @PostMapping()
-    public BaseResponse<BaseResultDto> addSchedule(@PathVariable Long groupId,
+    public BaseResponse<BaseResultDto> addSchedule(@RequestHeader(name = "Access-Member-Id") Long memberId,
+                                                   @PathVariable Long groupId,
                                                    @RequestBody @Valid ScheduleAddDto scheduleDto){
-        Long addId = scheduleService.addSchedule(null, groupId, scheduleDto);
+        Long addId = scheduleService.addSchedule(memberId, groupId, scheduleDto);
 
         return BaseResponse.getSimpleRes(addId);
     }
 
     @PatchMapping("/{scheduleId}")
-    public BaseResponse<BaseResultDto> updateSchedule(@PathVariable Long groupId,
+    public BaseResponse<BaseResultDto> updateSchedule(@RequestHeader(name = "Access-Member-Id") Long memberId,
+                                                      @PathVariable Long groupId,
                                                       @PathVariable Long scheduleId,
                                                       @RequestBody @Valid ScheduleUpdateDto scheduleDto){
-        Long updateId = scheduleService.updateSchedule(null, scheduleId, scheduleDto);
+        Long updateId = scheduleService.updateSchedule(memberId, scheduleId, scheduleDto);
 
         return BaseResponse.getSimpleRes(updateId);
     }
 
     @PostMapping("/{scheduleId}/enter")
-    public BaseResponse<BaseResultDto> enterSchedule(@PathVariable Long groupId,
-                                                      @PathVariable Long scheduleId,
-                                                      @RequestBody @Valid ScheduleEnterDto enterDto){
-        Long enterId = scheduleService.enterSchedule(null, groupId, scheduleId, enterDto);
+    public BaseResponse<BaseResultDto> enterSchedule(@RequestHeader(name = "Access-Member-Id") Long memberId,
+                                                     @PathVariable Long groupId,
+                                                     @PathVariable Long scheduleId,
+                                                     @RequestBody @Valid ScheduleEnterDto enterDto){
+        Long enterId = scheduleService.enterSchedule(memberId, groupId, scheduleId, enterDto);
 
         return BaseResponse.getSimpleRes(enterId);
     }
 
     @PostMapping("/{scheduleId}/exit")
-    public BaseResponse<BaseResultDto> exitSchedule(@PathVariable Long groupId,
-                                                     @PathVariable Long scheduleId){
-        Long exitId = scheduleService.exitSchedule(null, groupId, scheduleId);
+    public BaseResponse<BaseResultDto> exitSchedule(@RequestHeader(name = "Access-Member-Id") Long memberId,
+                                                    @PathVariable Long groupId,
+                                                    @PathVariable Long scheduleId){
+        Long exitId = scheduleService.exitSchedule(memberId, groupId, scheduleId);
 
         return BaseResponse.getSimpleRes(exitId);
     }
 
     @GetMapping("/{scheduleId}")
-    public BaseResponse<ScheduleDetailResDto> getScheduleDetail(@PathVariable Long groupId,
+    public BaseResponse<ScheduleDetailResDto> getScheduleDetail(@RequestHeader(name = "Access-Member-Id") Long memberId,
+                                                                @PathVariable Long groupId,
                                                                 @PathVariable Long scheduleId){
-        ScheduleDetailResDto result = scheduleService.getScheduleDetail(null, groupId, scheduleId);
+        ScheduleDetailResDto result = scheduleService.getScheduleDetail(memberId, groupId, scheduleId);
 
         return new BaseResponse<>(result);
     }
 
     @GetMapping
-    public BaseResponse<TeamScheduleListResDto> getTeamScheduleList(@PathVariable Long groupId,
+    public BaseResponse<TeamScheduleListResDto> getTeamScheduleList(@RequestHeader(name = "Access-Member-Id") Long memberId,
+                                                                    @PathVariable Long groupId,
                                                                     @ModelAttribute SearchDateCond dateCond,
                                                                     @RequestParam(defaultValue = "1") int page){
-        TeamScheduleListResDto result = scheduleService.getTeamScheduleList(null, groupId, dateCond, page);
+        TeamScheduleListResDto result = scheduleService.getTeamScheduleList(memberId, groupId, dateCond, page);
 
         return new BaseResponse<>(result);
     }
 
     @GetMapping("/schedules")
-    public BaseResponse<MemberScheduleListResDto> getMemberScheduleList(@ModelAttribute SearchDateCond dateCond,
+    public BaseResponse<MemberScheduleListResDto> getMemberScheduleList(@RequestHeader(name = "Access-Member-Id") Long memberId,
+                                                                        @ModelAttribute SearchDateCond dateCond,
                                                                         @RequestParam(defaultValue = "1") int page){
-        MemberScheduleListResDto result = scheduleService.getMemberScheduleList(null, dateCond, page);
+        MemberScheduleListResDto result = scheduleService.getMemberScheduleList(memberId, dateCond, page);
 
         return new BaseResponse<>(result);
     }
 
     @GetMapping("/{scheduleId}/arrival/result")
-    public BaseResponse<String> getScheduleArrivalResult(@PathVariable Long groupId,
-                                                   @PathVariable Long scheduleId){
-        String result = scheduleService.getScheduleArrivalResult(null, groupId, scheduleId);
+    public BaseResponse<String> getScheduleArrivalResult(@RequestHeader(name = "Access-Member-Id") Long memberId,
+                                                         @PathVariable Long groupId,
+                                                         @PathVariable Long scheduleId){
+        String result = scheduleService.getScheduleArrivalResult(memberId, groupId, scheduleId);
 
         return new BaseResponse<>(result);
     }
 
     @GetMapping("/{scheduleId}/betting/result")
-    public BaseResponse<String> getScheduleBettingResult(@PathVariable Long groupId,
+    public BaseResponse<String> getScheduleBettingResult(@RequestHeader(name = "Access-Member-Id") Long memberId,
+                                                         @PathVariable Long groupId,
                                                          @PathVariable Long scheduleId){
-        String result = scheduleService.getScheduleBettingResult(null, groupId, scheduleId);
+        String result = scheduleService.getScheduleBettingResult(memberId, groupId, scheduleId);
 
         return new BaseResponse<>(result);
     }

--- a/aiku/aiku-main/src/main/java/aiku_main/controller/TeamController.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/controller/TeamController.java
@@ -20,50 +20,57 @@ public class TeamController {
     private final TeamService teamService;
 
     @PostMapping
-    public BaseResponse addTeam(@RequestBody @Valid TeamAddDto teamDto){
-        Long teamId = teamService.addTeam(null, teamDto);
+    public BaseResponse addTeam(@RequestHeader(name = "Access-Member-Id") Long memberId,
+                                @RequestBody @Valid TeamAddDto teamDto){
+        Long teamId = teamService.addTeam(memberId, teamDto);
 
         return BaseResponse.getSimpleRes(teamId);
     }
 
     @PostMapping("/{groupId}/enter")
-    public BaseResponse enterTeam(@RequestParam Long groupId){
-        Long teamId = teamService.enterTeam(null, groupId);
+    public BaseResponse enterTeam(@RequestHeader(name = "Access-Member-Id") Long memberId,
+                                  @RequestParam Long groupId){
+        Long teamId = teamService.enterTeam(memberId, groupId);
 
         return BaseResponse.getSimpleRes(teamId);
     }
 
     @PostMapping("/{groupId}/exit")
-    public BaseResponse exitTeam(@RequestParam Long groupId){
-        Long teamId = teamService.exitTeam(null, groupId);
+    public BaseResponse exitTeam(@RequestHeader(name = "Access-Member-Id") Long memberId,
+                                 @RequestParam Long groupId){
+        Long teamId = teamService.exitTeam(memberId, groupId);
 
         return BaseResponse.getSimpleRes(teamId);
     }
 
     @GetMapping("/{groupId}")
-    public BaseResponse getGroupDetail(@RequestParam Long groupId){
-        TeamDetailResDto result = teamService.getTeamDetail(null, groupId);
+    public BaseResponse getGroupDetail(@RequestHeader(name = "Access-Member-Id") Long memberId,
+                                       @RequestParam Long groupId){
+        TeamDetailResDto result = teamService.getTeamDetail(memberId, groupId);
 
         return new BaseResponse(result);
     }
 
     @GetMapping
-    public BaseResponse getGroupList(@RequestParam(defaultValue = "1") int page){
-        DataResDto<List<TeamEachListResDto>> result = teamService.getTeamList(null, page);
+    public BaseResponse getGroupList(@RequestHeader(name = "Access-Member-Id") Long memberId,
+                                     @RequestParam(defaultValue = "1") int page){
+        DataResDto<List<TeamEachListResDto>> result = teamService.getTeamList(memberId, page);
 
         return new BaseResponse(result);
     }
 
     @GetMapping("/{groupId}/analytics/late")
-    public BaseResponse getGroupLateTimeResult(@PathVariable Long groupId){
-        String result = teamService.getTeamLateTimeResult(null, groupId);
+    public BaseResponse getGroupLateTimeResult(@RequestHeader(name = "Access-Member-Id") Long memberId,
+                                               @PathVariable Long groupId){
+        String result = teamService.getTeamLateTimeResult(memberId, groupId);
 
         return new BaseResponse(result);
     }
 
     @GetMapping("/{groupId}/analytics/betting")
-    public BaseResponse getGroupBettingResult(@PathVariable Long groupId){
-        String result = teamService.getTeamBettingResult(null, groupId);
+    public BaseResponse getGroupBettingResult(@RequestHeader(name = "Access-Member-Id") Long memberId,
+                                              @PathVariable Long groupId){
+        String result = teamService.getTeamBettingResult(memberId, groupId);
 
         return new BaseResponse(result);
     }

--- a/aiku/aiku-main/src/main/java/aiku_main/service/BettingService.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/service/BettingService.java
@@ -49,8 +49,9 @@ public class BettingService {
     private final ObjectMapper objectMapper;
 
     @Transactional
-    public Long addBetting(Member member, Long scheduleId, BettingAddDto bettingDto){
+    public Long addBetting(Long memberId, Long scheduleId, BettingAddDto bettingDto){
         //검증 로직
+        Member member = findMember(memberId);
         checkExistSchedule(scheduleId);
         checkScheduleWait(scheduleId);
         checkPaidScheduleMember(member.getId(), scheduleId);
@@ -72,8 +73,9 @@ public class BettingService {
     }
 
     @Transactional
-    public Long cancelBetting(Member member, Long scheduleId, Long bettingId){
+    public Long cancelBetting(Long memberId, Long scheduleId, Long bettingId){
         //검증 로직
+        Member member = findMember(memberId);
         ScheduleMember bettor = findScheduleMember(member.getId(), scheduleId);
         Betting betting = findBettingById(bettingId);
         checkBettingMember(betting, bettor);
@@ -211,6 +213,10 @@ public class BettingService {
     }
 
     //==* 기타 메서드 *==
+    private Member findMember(Long memberId){
+        return memberRepository.findById(memberId).orElseThrow();
+    }
+
     private Betting findBettingById(Long bettingId){
         Betting betting = bettingQueryRepository.findByIdAndStatus(bettingId, ALIVE).orElse(null);
         if (betting == null) {

--- a/aiku/aiku-main/src/test/java/aiku_main/controller/BettingControllerTest.java
+++ b/aiku/aiku-main/src/test/java/aiku_main/controller/BettingControllerTest.java
@@ -39,6 +39,7 @@ class BettingControllerTest {
     @Test
     void addBetting() throws Exception {
         mockMvc.perform(post("/schedules/1/bettings")
+                        .header("Access-Member-Id", 1L)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(
                                 new BettingAddDto(1L, 100)
@@ -49,6 +50,7 @@ class BettingControllerTest {
     @Test
     void addBettingWithFaultDto() throws Exception {
         mockMvc.perform(post("/schedules/1/bettings")
+                        .header("Access-Member-Id", 1L)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(
                                 new BettingAddDto(null, 100)
@@ -59,6 +61,7 @@ class BettingControllerTest {
     @Test
     void addBettingWithFaultPoint() throws Exception {
         mockMvc.perform(post("/schedules/1/bettings")
+                        .header("Access-Member-Id", 1L)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(
                                 new BettingAddDto(1L, 0)
@@ -66,6 +69,7 @@ class BettingControllerTest {
                 .andExpect(status().isBadRequest());
 
         mockMvc.perform(post("/schedules/1/bettings")
+                        .header("Access-Member-Id", 1L)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(
                                 new BettingAddDto(1L, 101)

--- a/aiku/aiku-main/src/test/java/aiku_main/controller/ScheduleControllerTest.java
+++ b/aiku/aiku-main/src/test/java/aiku_main/controller/ScheduleControllerTest.java
@@ -47,6 +47,7 @@ class ScheduleControllerTest {
         ScheduleAddDto scheduleAddDto = new ScheduleAddDto("sche1",
                 new LocationDto("loc1", 1.1, 1.1), LocalDateTime.now().plusHours(1), 10);
         mockMvc.perform(post("/groups/1/schedules")
+                        .header("Access-Member-Id", 1L)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(scheduleAddDto)))
                 .andExpect(status().isOk());
@@ -55,6 +56,7 @@ class ScheduleControllerTest {
     @Test
     void addScheduleWithFaultDto() throws Exception {
         mockMvc.perform(post("/groups/1/schedules")
+                        .header("Access-Member-Id", 1L)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(
                                 new ScheduleAddDto(" ",
@@ -64,6 +66,7 @@ class ScheduleControllerTest {
                 .andExpect(status().isBadRequest());
 
         mockMvc.perform(post("/groups/1/schedules")
+                        .header("Access-Member-Id", 1L)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(
                                 new ScheduleAddDto("schedule name is too long",
@@ -73,6 +76,7 @@ class ScheduleControllerTest {
                 .andExpect(status().isBadRequest());
 
         mockMvc.perform(post("/groups/1/schedules")
+                        .header("Access-Member-Id", 1L)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(
                                 new ScheduleAddDto("name1",
@@ -82,6 +86,7 @@ class ScheduleControllerTest {
                 .andExpect(status().isBadRequest());
 
         mockMvc.perform(post("/groups/1/schedules")
+                        .header("Access-Member-Id", 1L)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(
                                 new ScheduleAddDto("name1",
@@ -91,6 +96,7 @@ class ScheduleControllerTest {
                 .andExpect(status().isBadRequest());
 
         mockMvc.perform(post("/groups/1/schedules")
+                        .header("Access-Member-Id", 1L)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(
                                 new ScheduleAddDto("name1",
@@ -103,6 +109,7 @@ class ScheduleControllerTest {
     @Test
     void addScheduleWithFaultPoint() throws Exception {
         mockMvc.perform(post("/groups/1/schedules")
+                        .header("Access-Member-Id", 1L)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(
                                 new ScheduleAddDto("name1",
@@ -112,6 +119,7 @@ class ScheduleControllerTest {
                 .andExpect(status().isBadRequest());
 
         mockMvc.perform(post("/groups/1/schedules")
+                        .header("Access-Member-Id", 1L)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(
                                 new ScheduleAddDto("name1",
@@ -124,6 +132,7 @@ class ScheduleControllerTest {
     @Test
     void addScheduleWithFaultScheduleTime() throws Exception {
         mockMvc.perform(post("/groups/1/schedules")
+                        .header("Access-Member-Id", 1L)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(
                                 new ScheduleAddDto("name1",
@@ -138,6 +147,7 @@ class ScheduleControllerTest {
         ScheduleUpdateDto scheduleUpdateDto = new ScheduleUpdateDto("sche1",
                 new LocationDto("loc1", 1.1, 1.1), LocalDateTime.now().plusHours(1));
         mockMvc.perform(patch("/groups/1/schedules/1")
+                        .header("Access-Member-Id", 1L)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(scheduleUpdateDto)))
                 .andExpect(status().isOk());
@@ -148,6 +158,7 @@ class ScheduleControllerTest {
         ScheduleUpdateDto scheduleUpdateDto = new ScheduleUpdateDto(" ",
                 new LocationDto("loc1", 1.1, 1.1), LocalDateTime.now().plusHours(1));
         mockMvc.perform(patch("/groups/1/schedules/1")
+                        .header("Access-Member-Id", 1L)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(scheduleUpdateDto)))
                 .andExpect(status().isBadRequest());
@@ -158,6 +169,7 @@ class ScheduleControllerTest {
         ScheduleUpdateDto scheduleUpdateDto = new ScheduleUpdateDto(" ",
                 new LocationDto("loc1", 1.1, 1.1), LocalDateTime.now().plusMinutes(30));
         mockMvc.perform(patch("/groups/1/schedules/1")
+                        .header("Access-Member-Id", 1L)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(scheduleUpdateDto)))
                 .andExpect(status().isBadRequest());
@@ -166,6 +178,7 @@ class ScheduleControllerTest {
     @Test
     void enterSchedule() throws Exception {
         mockMvc.perform(post("/groups/1/schedules/1/enter")
+                        .header("Access-Member-Id", 1L)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(new ScheduleEnterDto(0))))
                 .andExpect(status().isOk());
@@ -174,6 +187,7 @@ class ScheduleControllerTest {
     @Test
     void enterScheduleWithFaultPoint() throws Exception {
         mockMvc.perform(post("/groups/1/schedules/1/enter")
+                        .header("Access-Member-Id", 1L)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(new ScheduleEnterDto(3))))
                 .andExpect(status().isBadRequest());

--- a/aiku/aiku-main/src/test/java/aiku_main/controller/TeamControllerTest.java
+++ b/aiku/aiku-main/src/test/java/aiku_main/controller/TeamControllerTest.java
@@ -36,6 +36,7 @@ class TeamControllerTest {
     void addTeam() throws Exception {
         TeamAddDto teamAddDto = new TeamAddDto("group name");
         mockMvc.perform(post("/groups")
+                .header("Access-Member-Id", 1L)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(teamAddDto)))
                 .andExpect(status().isOk());
@@ -43,7 +44,7 @@ class TeamControllerTest {
 
     @Test
     void addTeamWithFaultDto() throws Exception {
-        mockMvc.perform(post("/groups")
+        mockMvc.perform(post("/groups").header("Access-Member-Id", 1L)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(new TeamAddDto(" "))))
                 .andExpect(status().isBadRequest());

--- a/aiku/aiku-main/src/test/java/aiku_main/integration_test/BettingServiceIntegrationTest.java
+++ b/aiku/aiku-main/src/test/java/aiku_main/integration_test/BettingServiceIntegrationTest.java
@@ -91,7 +91,7 @@ class BettingServiceIntegrationTest {
     void 베팅_등록() {
         //when
         BettingAddDto bettingDto = new BettingAddDto(member2.getId(), 0);
-        Long bettingId = bettingService.addBetting(member1, schedule1.getId(), bettingDto);
+        Long bettingId = bettingService.addBetting(member1.getId(), schedule1.getId(), bettingDto);
 
         //then
         Betting betting = bettingQueryRepository.findById(bettingId).orElse(null);
@@ -110,21 +110,21 @@ class BettingServiceIntegrationTest {
 
         //when
         BettingAddDto bettingDto = new BettingAddDto(member2.getId(), 0);
-        assertThatThrownBy(() -> bettingService.addBetting(member1, schedule1.getId(), bettingDto)).isInstanceOf(ScheduleException.class);
+        assertThatThrownBy(() -> bettingService.addBetting(member1.getId(), schedule1.getId(), bettingDto)).isInstanceOf(ScheduleException.class);
     }
 
     @Test
     void 베팅_등록_스케줄멤버x() {
         //when
         BettingAddDto bettingDto = new BettingAddDto(member2.getId(), 0);
-        assertThatThrownBy(() -> bettingService.addBetting(noScheduleMember, schedule1.getId(), bettingDto)).isInstanceOf(BaseException.class);
+        assertThatThrownBy(() -> bettingService.addBetting(noScheduleMember.getId(), schedule1.getId(), bettingDto)).isInstanceOf(BaseException.class);
     }
 
     @Test
     void 베팅_등록_깍두기멤버() {
         //when
         BettingAddDto bettingDto = new BettingAddDto(freeMember.getId(), 0);
-        assertThatThrownBy(() -> bettingService.addBetting(noScheduleMember, schedule1.getId(), bettingDto)).isInstanceOf(PaidMemberLimitException.class);
+        assertThatThrownBy(() -> bettingService.addBetting(noScheduleMember.getId(), schedule1.getId(), bettingDto)).isInstanceOf(PaidMemberLimitException.class);
     }
 
     @Test
@@ -138,7 +138,7 @@ class BettingServiceIntegrationTest {
 
         //when
         BettingAddDto bettingDto = new BettingAddDto(member2.getId(), 0);
-        assertThatThrownBy(() -> bettingService.addBetting(member1, schedule1.getId(), bettingDto)).isInstanceOf(BettingException.class);
+        assertThatThrownBy(() -> bettingService.addBetting(member1.getId(), schedule1.getId(), bettingDto)).isInstanceOf(BettingException.class);
     }
 
     @Test
@@ -147,7 +147,7 @@ class BettingServiceIntegrationTest {
         BettingAddDto bettingDto = new BettingAddDto(member2.getId(), 1000);
 
         //then
-        assertThatThrownBy(() -> bettingService.addBetting(member1, schedule1.getId(), bettingDto)).isInstanceOf(NotEnoughPoint.class);
+        assertThatThrownBy(() -> bettingService.addBetting(member1.getId(), schedule1.getId(), bettingDto)).isInstanceOf(NotEnoughPoint.class);
     }
 
     @Test
@@ -160,7 +160,7 @@ class BettingServiceIntegrationTest {
         em.persist(betting);
 
         //when
-        bettingService.cancelBetting(member1, schedule1.getId(), betting.getId());
+        bettingService.cancelBetting(member1.getId(), schedule1.getId(), betting.getId());
 
         //then
         Betting findBetting = bettingQueryRepository.findById(betting.getId()).orElseThrow();
@@ -178,8 +178,8 @@ class BettingServiceIntegrationTest {
         em.persist(betting);
 
         //when
-        bettingService.cancelBetting(member1, schedule1.getId(), betting.getId());
-        assertThatThrownBy(() -> bettingService.cancelBetting(member1, schedule1.getId(), betting.getId())).isInstanceOf(BettingException.class);
+        bettingService.cancelBetting(member1.getId(), schedule1.getId(), betting.getId());
+        assertThatThrownBy(() -> bettingService.cancelBetting(member1.getId(), schedule1.getId(), betting.getId())).isInstanceOf(BettingException.class);
     }
 
     @Test
@@ -192,7 +192,7 @@ class BettingServiceIntegrationTest {
         em.persist(betting);
 
         //when
-        assertThatThrownBy(() -> bettingService.cancelBetting(member2, schedule1.getId(), betting.getId())).isInstanceOf(BettingException.class);
+        assertThatThrownBy(() -> bettingService.cancelBetting(member2.getId(), schedule1.getId(), betting.getId())).isInstanceOf(BettingException.class);
     }
 
     @Test
@@ -205,7 +205,7 @@ class BettingServiceIntegrationTest {
         em.persist(betting);
 
         //when
-        assertThatThrownBy(() -> bettingService.cancelBetting(noScheduleMember, schedule1.getId(), betting.getId())).isInstanceOf(ScheduleException.class);
+        assertThatThrownBy(() -> bettingService.cancelBetting(noScheduleMember.getId(), schedule1.getId(), betting.getId())).isInstanceOf(ScheduleException.class);
     }
 
     @Test

--- a/aiku/aiku-main/src/test/java/aiku_main/integration_test/ScheduleServiceIntegrationTest.java
+++ b/aiku/aiku-main/src/test/java/aiku_main/integration_test/ScheduleServiceIntegrationTest.java
@@ -86,7 +86,7 @@ public class ScheduleServiceIntegrationTest {
         //when
         ScheduleAddDto scheduleDto = new ScheduleAddDto("sche1",
                 new LocationDto("lo1", 1.0, 1.0), LocalDateTime.now().plusHours(1), 0);
-        Long scheduleId = scheduleService.addSchedule(member1, team.getId(), scheduleDto);
+        Long scheduleId = scheduleService.addSchedule(member1.getId(), team.getId(), scheduleDto);
 
         //then
         Schedule schedule = scheduleQueryRepository.findById(scheduleId).orElse(null);
@@ -105,7 +105,7 @@ public class ScheduleServiceIntegrationTest {
         //when
         ScheduleAddDto scheduleDto = new ScheduleAddDto("sche1",
                 new LocationDto("lo1", 1.0, 1.0), LocalDateTime.now().plusHours(1), 0);
-        assertThatThrownBy(() -> scheduleService.addSchedule(member2, team.getId(), scheduleDto)).isInstanceOf(TeamException.class);
+        assertThatThrownBy(() -> scheduleService.addSchedule(member2.getId(), team.getId(), scheduleDto)).isInstanceOf(TeamException.class);
     }
 
     @Test
@@ -120,7 +120,7 @@ public class ScheduleServiceIntegrationTest {
         //when
         ScheduleUpdateDto scheduleDto = new ScheduleUpdateDto("new",
                 new LocationDto("new", 2.0, 2.0), LocalDateTime.now().plusHours(2));
-        scheduleService.updateSchedule(member1, schedule.getId(), scheduleDto);
+        scheduleService.updateSchedule(member1.getId(), schedule.getId(), scheduleDto);
 
         //then
         Schedule findSchedule = scheduleQueryRepository.findById(schedule.getId()).get();
@@ -142,7 +142,7 @@ public class ScheduleServiceIntegrationTest {
         //when
         ScheduleUpdateDto scheduleDto = new ScheduleUpdateDto("new",
                 new LocationDto("new", 2.0, 2.0), LocalDateTime.now().plusHours(2));
-        assertThatThrownBy(() -> scheduleService.updateSchedule(member2, schedule.getId(), scheduleDto)).isInstanceOf(ScheduleException.class);
+        assertThatThrownBy(() -> scheduleService.updateSchedule(member2.getId(), schedule.getId(), scheduleDto)).isInstanceOf(ScheduleException.class);
     }
 
     @Test
@@ -158,7 +158,7 @@ public class ScheduleServiceIntegrationTest {
         //when
         ScheduleUpdateDto scheduleDto = new ScheduleUpdateDto("new",
                 new LocationDto("new", 2.0, 2.0), LocalDateTime.now().plusHours(2));
-        assertThatThrownBy(() -> scheduleService.updateSchedule(member1, schedule.getId(), scheduleDto)).isInstanceOf(ScheduleException.class);
+        assertThatThrownBy(() -> scheduleService.updateSchedule(member1.getId(), schedule.getId(), scheduleDto)).isInstanceOf(ScheduleException.class);
     }
 
     @Test
@@ -173,7 +173,7 @@ public class ScheduleServiceIntegrationTest {
 
         //when
         ScheduleEnterDto enterDto = new ScheduleEnterDto(0);
-        Long scheduleId = scheduleService.enterSchedule(member2, team.getId(), schedule.getId(), enterDto);
+        Long scheduleId = scheduleService.enterSchedule(member2.getId(), team.getId(), schedule.getId(), enterDto);
 
         //then
         Schedule findSchedule = scheduleQueryRepository.findById(scheduleId).orElse(null);
@@ -200,7 +200,7 @@ public class ScheduleServiceIntegrationTest {
 
         //when
         ScheduleEnterDto enterDto = new ScheduleEnterDto(0);
-        assertThatThrownBy(() -> scheduleService.enterSchedule(member2, team.getId(), schedule.getId(), enterDto)).isInstanceOf(ScheduleException.class);
+        assertThatThrownBy(() -> scheduleService.enterSchedule(member2.getId(), team.getId(), schedule.getId(), enterDto)).isInstanceOf(ScheduleException.class);
     }
 
     @Test
@@ -214,7 +214,7 @@ public class ScheduleServiceIntegrationTest {
 
         //when
         ScheduleEnterDto enterDto = new ScheduleEnterDto(0);
-        assertThatThrownBy(() -> scheduleService.enterSchedule(member2, team.getId(), schedule.getId(), enterDto)).isInstanceOf(TeamException.class);
+        assertThatThrownBy(() -> scheduleService.enterSchedule(member2.getId(), team.getId(), schedule.getId(), enterDto)).isInstanceOf(TeamException.class);
     }
 
     @Test
@@ -230,7 +230,7 @@ public class ScheduleServiceIntegrationTest {
 
         //when
         ScheduleEnterDto enterDto = new ScheduleEnterDto(0);
-        assertThatThrownBy(() -> scheduleService.enterSchedule(member2, team.getId(), schedule.getId(), enterDto)).isInstanceOf(ScheduleException.class);
+        assertThatThrownBy(() -> scheduleService.enterSchedule(member2.getId(), team.getId(), schedule.getId(), enterDto)).isInstanceOf(ScheduleException.class);
     }
 
     @Test
@@ -247,7 +247,7 @@ public class ScheduleServiceIntegrationTest {
         em.persist(schedule);
 
         //when
-        scheduleService.exitSchedule(member2, team.getId(), schedule.getId());
+        scheduleService.exitSchedule(member2.getId(), team.getId(), schedule.getId());
 
         //then
         Schedule findSchedule = scheduleQueryRepository.findById(schedule.getId()).orElse(null);
@@ -262,8 +262,6 @@ public class ScheduleServiceIntegrationTest {
         ScheduleMember owner = scheduleQueryRepository.findScheduleMember(member1.getId(), schedule.getId()).orElse(null);
         assertThat(owner).isNotNull();
         assertThat(owner.isOwner()).isTrue();
-        //중복 요청
-        assertThatThrownBy(() -> scheduleService.exitSchedule(member2, team.getId(), schedule.getId())).isInstanceOf(ScheduleException.class);
     }
 
     @Test
@@ -277,7 +275,7 @@ public class ScheduleServiceIntegrationTest {
         em.persist(schedule);
 
         //when
-        assertThatThrownBy(() -> scheduleService.exitSchedule(member2, team.getId(), schedule.getId())).isInstanceOf(ScheduleException.class);
+        assertThatThrownBy(() -> scheduleService.exitSchedule(member2.getId(), team.getId(), schedule.getId())).isInstanceOf(ScheduleException.class);
     }
 
     @Test
@@ -291,10 +289,10 @@ public class ScheduleServiceIntegrationTest {
         schedule.addScheduleMember(member2, false, 0);
         em.persist(schedule);
 
-        scheduleService.exitSchedule(member2, team.getId(), schedule.getId());
+        scheduleService.exitSchedule(member2.getId(), team.getId(), schedule.getId());
 
         //when
-        assertThatThrownBy(() -> scheduleService.exitSchedule(member2, team.getId(), schedule.getId())).isInstanceOf(ScheduleException.class);
+        assertThatThrownBy(() -> scheduleService.exitSchedule(member2.getId(), team.getId(), schedule.getId())).isInstanceOf(ScheduleException.class);
     }
 
     @Test
@@ -307,7 +305,7 @@ public class ScheduleServiceIntegrationTest {
         em.persist(schedule);
 
         //when
-        scheduleService.exitSchedule(member1, team.getId(), schedule.getId());
+        scheduleService.exitSchedule(member1.getId(), team.getId(), schedule.getId());
 
         //then
         Schedule findSchedule = scheduleQueryRepository.findById(schedule.getId()).orElse(null);
@@ -330,7 +328,7 @@ public class ScheduleServiceIntegrationTest {
         em.persist(schedule);
 
         //when
-        scheduleService.exitSchedule(member1, team.getId(), schedule.getId());
+        scheduleService.exitSchedule(member1.getId(), team.getId(), schedule.getId());
 
         //then
         Schedule findSchedule = scheduleQueryRepository.findById(schedule.getId()).orElse(null);
@@ -355,7 +353,7 @@ public class ScheduleServiceIntegrationTest {
         em.persist(schedule);
 
         //when
-        assertThatThrownBy(() -> scheduleService.exitSchedule(member1, team.getId(), schedule.getId())).isInstanceOf(ScheduleException.class);
+        assertThatThrownBy(() -> scheduleService.exitSchedule(member1.getId(), team.getId(), schedule.getId())).isInstanceOf(ScheduleException.class);
     }
 
     @Test
@@ -410,7 +408,7 @@ public class ScheduleServiceIntegrationTest {
         em.persist(schedule);
 
         //when
-        ScheduleDetailResDto resultDto = scheduleService.getScheduleDetail(member1, team.getId(), schedule.getId());
+        ScheduleDetailResDto resultDto = scheduleService.getScheduleDetail(member1.getId(), team.getId(), schedule.getId());
 
         //then
         assertThat(resultDto.getScheduleId()).isEqualTo(schedule.getId());
@@ -435,7 +433,7 @@ public class ScheduleServiceIntegrationTest {
         em.persist(schedule);
 
         //when
-        assertThatThrownBy(() -> scheduleService.getScheduleDetail(member4, team.getId(), schedule.getId())).isInstanceOf(ScheduleException.class);
+        assertThatThrownBy(() -> scheduleService.getScheduleDetail(member4.getId(), team.getId(), schedule.getId())).isInstanceOf(ScheduleException.class);
     }
 
     @Test
@@ -460,7 +458,7 @@ public class ScheduleServiceIntegrationTest {
         em.persist(schedule3);
 
         //when
-        TeamScheduleListResDto result = scheduleService.getTeamScheduleList(member1, team.getId(), new SearchDateCond(), 1);
+        TeamScheduleListResDto result = scheduleService.getTeamScheduleList(member1.getId(), team.getId(), new SearchDateCond(), 1);
 
         //then
         assertThat(result.getRunSchedule()).isEqualTo(1);
@@ -479,7 +477,7 @@ public class ScheduleServiceIntegrationTest {
         em.persist(team);
 
         //when
-        assertThatThrownBy(() -> scheduleService.getTeamScheduleList(member4, team.getId(), new SearchDateCond(), 1)).isInstanceOf(TeamException.class);
+        assertThatThrownBy(() -> scheduleService.getTeamScheduleList(member4.getId(), team.getId(), new SearchDateCond(), 1)).isInstanceOf(TeamException.class);
     }
 
     @Test
@@ -503,7 +501,7 @@ public class ScheduleServiceIntegrationTest {
         em.persist(schedule3);
 
         //when
-        TeamScheduleListResDto result = scheduleService.getTeamScheduleList(member1, team.getId(), new SearchDateCond(startDate, endDate), 1);
+        TeamScheduleListResDto result = scheduleService.getTeamScheduleList(member1.getId(), team.getId(), new SearchDateCond(startDate, endDate), 1);
 
         //then
         assertThat(result.getRunSchedule()).isEqualTo(0);
@@ -539,7 +537,7 @@ public class ScheduleServiceIntegrationTest {
         em.persist(scheduleB1);
 
         //when
-        MemberScheduleListResDto result = scheduleService.getMemberScheduleList(member1, new SearchDateCond(), 1);
+        MemberScheduleListResDto result = scheduleService.getMemberScheduleList(member1.getId(), new SearchDateCond(), 1);
 
         //then
         assertThat(result.getWaitSchedule()).isEqualTo(0);
@@ -581,7 +579,7 @@ public class ScheduleServiceIntegrationTest {
         em.persist(scheduleB2);
 
         //when
-        MemberScheduleListResDto result = scheduleService.getMemberScheduleList(member1, new SearchDateCond(startDate, null), 1);
+        MemberScheduleListResDto result = scheduleService.getMemberScheduleList(member1.getId(), new SearchDateCond(startDate, null), 1);
 
         //then
         assertThat(result.getWaitSchedule()).isEqualTo(1);

--- a/aiku/aiku-main/src/test/java/aiku_main/integration_test/TeamServiceIntegrationTest.java
+++ b/aiku/aiku-main/src/test/java/aiku_main/integration_test/TeamServiceIntegrationTest.java
@@ -69,7 +69,7 @@ public class TeamServiceIntegrationTest {
         //given
         //when
         TeamAddDto teamDto = new TeamAddDto("group1");
-        Long teamId = teamService.addTeam(member1, teamDto);
+        Long teamId = teamService.addTeam(member1.getId(), teamDto);
 
         em.flush();
         em.clear();
@@ -93,14 +93,11 @@ public class TeamServiceIntegrationTest {
         em.clear();
 
         //when
-        Long teamId = teamService.enterTeam(member2, team.getId());
+        Long teamId = teamService.enterTeam(member2.getId(), team.getId());
 
         //then
         TeamMember teamMember = teamQueryRepository.findAliveTeamMember(teamId, member2.getId()).orElse(null);
         assertThat(teamMember).isNotNull();
-
-        //중복 입장
-        assertThatThrownBy(() -> teamService.enterTeam(member2, team.getId())).isInstanceOf(TeamException.class);
     }
 
     @Test
@@ -114,7 +111,7 @@ public class TeamServiceIntegrationTest {
         em.clear();
 
         //when
-        assertThatThrownBy(() -> teamService.enterTeam(member2, team.getId())).isInstanceOf(TeamException.class);
+        assertThatThrownBy(() -> teamService.enterTeam(member2.getId(), team.getId())).isInstanceOf(TeamException.class);
     }
 
     @Test
@@ -129,7 +126,7 @@ public class TeamServiceIntegrationTest {
         em.clear();
 
         //when
-        teamService.exitTeam(member2, team.getId());
+        teamService.exitTeam(member2.getId(), team.getId());
         em.flush();
         em.clear();
 
@@ -153,7 +150,7 @@ public class TeamServiceIntegrationTest {
         em.clear();
 
         //when
-        assertThatThrownBy(() -> teamService.exitTeam(member2, team.getId())).isInstanceOf(TeamException.class);
+        assertThatThrownBy(() -> teamService.exitTeam(member2.getId(), team.getId())).isInstanceOf(TeamException.class);
     }
 
     @Test
@@ -164,12 +161,12 @@ public class TeamServiceIntegrationTest {
         team.addTeamMember(member2);
         em.persist(team);
 
-        teamService.exitTeam(member2, team.getId());
+        teamService.exitTeam(member2.getId(), team.getId());
         em.flush();
         em.clear();
 
         //when
-        assertThatThrownBy(() -> teamService.exitTeam(member2, team.getId())).isInstanceOf(TeamException.class);
+        assertThatThrownBy(() -> teamService.exitTeam(member2.getId(), team.getId())).isInstanceOf(TeamException.class);
     }
 
     @Test
@@ -182,7 +179,7 @@ public class TeamServiceIntegrationTest {
         em.clear();
 
         //when
-        teamService.exitTeam(member1, team.getId());
+        teamService.exitTeam(member1.getId(), team.getId());
         em.flush();
         em.clear();
 
@@ -203,7 +200,7 @@ public class TeamServiceIntegrationTest {
         em.clear();
 
         //when
-        TeamDetailResDto result = teamService.getTeamDetail(member1, team.getId());
+        TeamDetailResDto result = teamService.getTeamDetail(member1.getId(), team.getId());
 
         //then
         assertThat(result.getGroupId()).isEqualTo(team.getId());
@@ -224,7 +221,7 @@ public class TeamServiceIntegrationTest {
         em.clear();
 
         //when
-        assertThatThrownBy(() -> teamService.getTeamDetail(member2, team.getId())).isInstanceOf(TeamException.class);
+        assertThatThrownBy(() -> teamService.getTeamDetail(member2.getId(), team.getId())).isInstanceOf(TeamException.class);
     }
 
     @Test
@@ -273,7 +270,7 @@ public class TeamServiceIntegrationTest {
 
         //when
         int page = 1;
-        DataResDto<List<TeamEachListResDto>> result = teamService.getTeamList(member1, page);
+        DataResDto<List<TeamEachListResDto>> result = teamService.getTeamList(member1.getId(), page);
 
         //then
         List<TeamEachListResDto> data = result.getData();

--- a/aiku/aiku-main/src/test/java/aiku_main/service/ScheduleServiceTest.java
+++ b/aiku/aiku-main/src/test/java/aiku_main/service/ScheduleServiceTest.java
@@ -5,6 +5,7 @@ import aiku_main.dto.LocationDto;
 import aiku_main.dto.ScheduleDetailResDto;
 import aiku_main.dto.ScheduleUpdateDto;
 import aiku_main.kafka.KafkaProducerService;
+import aiku_main.repository.MemberRepository;
 import aiku_main.repository.ScheduleQueryRepository;
 import aiku_main.repository.TeamQueryRepository;
 import aiku_main.scheduler.ScheduleScheduler;
@@ -16,6 +17,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.lang.Nullable;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -33,6 +35,8 @@ class ScheduleServiceTest {
     ScheduleQueryRepository scheduleQueryRepository;
     @Mock
     TeamQueryRepository teamQueryRepository;
+    @Mock
+    MemberRepository memberRepository;
     @Mock
     ScheduleScheduler scheduleScheduler;
     @Mock
@@ -53,12 +57,13 @@ class ScheduleServiceTest {
         doReturn(scheduleId).when(schedule).getId();
         when(scheduleQueryRepository.findByIdAndStatus(nullable(Long.class), any())).thenReturn(Optional.of(schedule));
         when(scheduleQueryRepository.isScheduleOwner(nullable(Long.class), nullable(Long.class))).thenReturn(true);
+        when(memberRepository.findById(nullable(Long.class))).thenReturn(Optional.ofNullable(member));
 
         //when
         ScheduleUpdateDto scheduleDto = new ScheduleUpdateDto("new Schedule",
                 new LocationDto("new location", 2.2, 2.2),
                 LocalDateTime.now());
-        Long resultId = scheduleService.updateSchedule(member, schedule.getId(), scheduleDto);
+        Long resultId = scheduleService.updateSchedule(member.getId(), schedule.getId(), scheduleDto);
 
         //then
         assertThat(resultId).isEqualTo(scheduleId);
@@ -80,7 +85,7 @@ class ScheduleServiceTest {
         when(scheduleQueryRepository.getScheduleMembersWithMember(nullable(Long.class))).thenReturn(null);
 
         //when
-        ScheduleDetailResDto result = scheduleService.getScheduleDetail(member1, null, null);
+        ScheduleDetailResDto result = scheduleService.getScheduleDetail(member1.getId(), null, null);
 
         //then
         assertThat(result.getScheduleName()).isEqualTo(schedule.getScheduleName());

--- a/aiku/aiku-main/src/test/java/aiku_main/service/TeamServiceTest.java
+++ b/aiku/aiku-main/src/test/java/aiku_main/service/TeamServiceTest.java
@@ -2,6 +2,8 @@ package aiku_main.service;
 
 import aiku_main.application_event.publisher.TeamEventPublisher;
 import aiku_main.dto.*;
+import aiku_main.repository.BettingQueryRepository;
+import aiku_main.repository.MemberRepository;
 import aiku_main.repository.ScheduleQueryRepository;
 import aiku_main.repository.TeamQueryRepository;
 import common.domain.member.Member;
@@ -28,6 +30,10 @@ class TeamServiceTest {
     @Mock
     ScheduleQueryRepository scheduleQueryRepository;
     @Mock
+    BettingQueryRepository bettingQueryRepository;
+    @Mock
+    MemberRepository memberRepository;
+    @Mock
     TeamEventPublisher teamEventPublisher;
 
     @InjectMocks
@@ -38,9 +44,11 @@ class TeamServiceTest {
         //given
         Member member = new Member("member1");
 
+        when(memberRepository.findById(nullable(Long.class))).thenReturn(Optional.of(member));
+
         //when
         TeamAddDto teamDto = new TeamAddDto("team1");
-        Long teamId = teamService.addTeam(member, teamDto);
+        Long teamId = teamService.addTeam(member.getId(), teamDto);
     }
 
     @Test
@@ -51,9 +59,10 @@ class TeamServiceTest {
 
         when(teamQueryRepository.existTeamMember(any(), any())).thenReturn(false);
         when(teamQueryRepository.findByIdAndStatus(any(), any())).thenReturn(Optional.of(team));
+        when(memberRepository.findById(nullable(Long.class))).thenReturn(Optional.of(member));
 
         //when
-        Long resultId = teamService.enterTeam(member, null);
+        Long resultId = teamService.enterTeam(member.getId(), null);
     }
 
     @Test
@@ -69,7 +78,7 @@ class TeamServiceTest {
         when(teamQueryRepository.findTeamWithMember(any())).thenReturn(Optional.of(team));
 
         //when
-        TeamDetailResDto result = teamService.getTeamDetail(member1, team.getId());
+        TeamDetailResDto result = teamService.getTeamDetail(member1.getId(), team.getId());
 
         //then
         assertThat(result.getGroupName()).isEqualTo(team.getTeamName());
@@ -88,7 +97,7 @@ class TeamServiceTest {
 
         //when
         int page = 3;
-        DataResDto<List<TeamEachListResDto>> result = teamService.getTeamList(member1, 3);
+        DataResDto<List<TeamEachListResDto>> result = teamService.getTeamList(member1.getId(), 3);
 
         //then
         assertThat(result.getPage()).isEqualTo(3);


### PR DESCRIPTION
## 관련 이슈 번호

- #65 

<br />

## 작업 사항

- Controller에 Access-Member-Id 의 헤더 파싱 추가
- Service의 메서드에 넘어오던 Member를 Long타입의 memberId로 변경
- 변경에 따른 테스트 수정

<br />

## 기타 사항
<br />
