### PR TITLE
레이싱 생성 시 ScheduleMember의 id를 이용하도록 수정

### DIFF
--- a/aiku/aiku-common/src/main/java/common/domain/Racing.java
+++ b/aiku/aiku-common/src/main/java/common/domain/Racing.java
@@ -35,10 +35,10 @@ public class Racing extends BaseTime{
     @Enumerated(value = EnumType.STRING)
     private Status status;
 
-    public static Racing create(Long firstRacerId, Long secondRacerId, Integer pointAmount) {
+    public static Racing create(Long firstScheduleMemberId, Long secondScheduleMemberId, Integer pointAmount) {
         Racing racing = new Racing();
-        racing.firstRacer = new ScheduleMemberValue(firstRacerId);
-        racing.secondRacer = new ScheduleMemberValue(secondRacerId);
+        racing.firstRacer = new ScheduleMemberValue(firstScheduleMemberId);
+        racing.secondRacer = new ScheduleMemberValue(secondScheduleMemberId);
         racing.pointAmount = pointAmount;
 
         racing.raceStatus = ExecStatus.WAIT;

--- a/aiku/aiku-map/src/main/java/map/repository/ScheduleQueryRepository.java
+++ b/aiku/aiku-map/src/main/java/map/repository/ScheduleQueryRepository.java
@@ -15,4 +15,6 @@ public interface ScheduleQueryRepository {
     Optional<ScheduleMember> findScheduleMember(Long memberId, Long scheduleId);
 
     boolean existPaidScheduleMember(Long memberId, Long scheduleId);
+
+    Optional<Long> findScheduleMemberIdByMemberAndScheduleId(Long memberId, Long scheduleId);
 }

--- a/aiku/aiku-map/src/main/java/map/repository/ScheduleQueryRepositoryImpl.java
+++ b/aiku/aiku-map/src/main/java/map/repository/ScheduleQueryRepositoryImpl.java
@@ -76,4 +76,16 @@ public class ScheduleQueryRepositoryImpl implements ScheduleQueryRepository {
         return count != null && count > 0;
     }
 
+    @Override
+    public Optional<Long> findScheduleMemberIdByMemberAndScheduleId(Long memberId, Long scheduleId) {
+        Long scheduleMemberId = query.select(scheduleMember.id)
+                .from(schedule)
+                .leftJoin(schedule.scheduleMembers, scheduleMember)
+                .leftJoin(scheduleMember.member, member)
+                .where(schedule.id.eq(scheduleId), member.id.eq(memberId))
+                .fetchOne();
+
+        return Optional.ofNullable(scheduleMemberId);
+    }
+
 }


### PR DESCRIPTION
## 관련 이슈 번호
<br />

- #72 
## 작업 사항
<br />

- member의 id를 통해 scheduleMemberId를 조회하는 로직 추가
- makeRacing 로직에서 scheduleMemberId를 이용해 Racing을 생성하도록 수정
## 기타 사항
<br />
