### PR TITLE
스케줄 상세 조회, 그룹 분석 디자인에 맞춰 기능 보강

### DIFF
--- a/aiku/aiku-main/src/main/java/aiku_main/application_event/domain/TeamLateTimeResult.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/application_event/domain/TeamLateTimeResult.java
@@ -10,6 +10,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class TeamLateTimeResult {
+
     private Long groupId;
     private List<TeamResultMember> members;
 }

--- a/aiku/aiku-main/src/main/java/aiku_main/application_event/domain/TeamResultMember.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/application_event/domain/TeamResultMember.java
@@ -12,14 +12,16 @@ import static common.domain.Status.ALIVE;
 @Getter @Setter
 @NoArgsConstructor
 public class TeamResultMember {
+
     private Long memberId;
     private String nickname;
     private MemberProfileResDto memberProfile;
     private int analysis;
+    private int previousRank;
+    private int rank;
     private boolean isTeamMember;
 
     @QueryProjection
-
     public TeamResultMember(Long memberId, String nickname, MemberProfileResDto memberProfile, int analysis, Status isTeamMember) {
         this.memberId = memberId;
         this.nickname = nickname;

--- a/aiku/aiku-main/src/main/java/aiku_main/application_event/domain/TeamResultMember.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/application_event/domain/TeamResultMember.java
@@ -3,6 +3,7 @@ package aiku_main.application_event.domain;
 import aiku_main.dto.MemberProfileResDto;
 import com.querydsl.core.annotations.QueryProjection;
 import common.domain.Status;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -27,6 +28,15 @@ public class TeamResultMember {
         this.nickname = nickname;
         this.memberProfile = memberProfile;
         this.analysis = analysis;
+        this.isTeamMember = isTeamMember == ALIVE ? true : false;
+    }
+
+    public TeamResultMember(Long memberId, String nickname, MemberProfileResDto memberProfile, int analysis, int previousRank, Status isTeamMember) {
+        this.memberId = memberId;
+        this.nickname = nickname;
+        this.memberProfile = memberProfile;
+        this.analysis = analysis;
+        this.previousRank = previousRank;
         this.isTeamMember = isTeamMember == ALIVE ? true : false;
     }
 }

--- a/aiku/aiku-main/src/main/java/aiku_main/dto/ScheduleMemberResDto.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/dto/ScheduleMemberResDto.java
@@ -9,14 +9,16 @@ public class ScheduleMemberResDto {
     private Long memberId;
     private String nickname;
     private MemberProfileResDto memberProfile;
+    private boolean isOwner;
     private int point;
     private boolean isBetee;
 
     @QueryProjection
-    public ScheduleMemberResDto(Long memberId, String nickname, MemberProfileResDto memberProfile, int point, Long beteeId) {
+    public ScheduleMemberResDto(Long memberId, String nickname, MemberProfileResDto memberProfile, boolean isOwner, int point, Long beteeId) {
         this.memberId = memberId;
         this.nickname = nickname;
         this.memberProfile = memberProfile;
+        this.isOwner = isOwner;
         this.point = point;
         this.isBetee = (beteeId == null)? false : true;
     }

--- a/aiku/aiku-main/src/main/java/aiku_main/dto/ScheduleMemberResDto.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/dto/ScheduleMemberResDto.java
@@ -10,12 +10,14 @@ public class ScheduleMemberResDto {
     private String nickname;
     private MemberProfileResDto memberProfile;
     private int point;
+    private boolean isBetee;
 
     @QueryProjection
-    public ScheduleMemberResDto(Long memberId, String nickname, MemberProfileResDto memberProfile, int point) {
+    public ScheduleMemberResDto(Long memberId, String nickname, MemberProfileResDto memberProfile, int point, Long beteeId) {
         this.memberId = memberId;
         this.nickname = nickname;
         this.memberProfile = memberProfile;
         this.point = point;
+        this.isBetee = (beteeId == null)? false : true;
     }
 }

--- a/aiku/aiku-main/src/main/java/aiku_main/repository/ScheduleQueryRepositoryCustom.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/repository/ScheduleQueryRepositoryCustom.java
@@ -33,7 +33,7 @@ public interface ScheduleQueryRepositoryCustom {
     int countTeamScheduleByScheduleStatus(Long teamId, ExecStatus scheduleStatus, SearchDateCond dateCond);
     int countMemberScheduleByScheduleStatus(Long memberId, ExecStatus scheduleStatus, SearchDateCond dateCond);
 
-    List<ScheduleMemberResDto> getScheduleMembersWithMember(Long scheduleId);
+    List<ScheduleMemberResDto> getScheduleMembersWithBettingInfo(Long memberId, Long scheduleId);
     List<TeamScheduleListEachResDto> getTeamSchedules(Long teamId, Long memberId, SearchDateCond dateCond, int page);
     List<MemberScheduleListEachResDto> getMemberSchedules(Long memberId, SearchDateCond dateCond, int page);
     List<ScheduleArrivalMember> getScheduleArrivalResults(Long scheduleId);

--- a/aiku/aiku-main/src/main/java/aiku_main/repository/ScheduleQueryRepositoryCustomImpl.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/repository/ScheduleQueryRepositoryCustomImpl.java
@@ -193,7 +193,7 @@ public class ScheduleQueryRepositoryCustomImpl implements ScheduleQueryRepositor
                         member.id, member.nickname,
                         Projections.constructor(MemberProfileResDto.class,
                                 member.profile.profileType, member.profile.profileImg, member.profile.profileCharacter, member.profile.profileBackground),
-                        member.point, betting.betee.id))
+                        scheduleMember.isOwner, member.point, betting.betee.id))
                 .from(scheduleMember)
                 .innerJoin(member).on(member.id.eq(scheduleMember.member.id))
                 .leftJoin(betting).on(betting.betee.id.eq(scheduleMember.id),

--- a/aiku/aiku-main/src/main/java/aiku_main/repository/ScheduleQueryRepositoryCustomImpl.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/repository/ScheduleQueryRepositoryCustomImpl.java
@@ -5,8 +5,11 @@ import aiku_main.dto.*;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import common.domain.ExecStatus;
+import common.domain.QBetting;
+import common.domain.schedule.QScheduleMember;
 import common.domain.schedule.Schedule;
 import common.domain.schedule.ScheduleMember;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +19,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static common.domain.ExecStatus.WAIT;
+import static common.domain.QBetting.betting;
 import static common.domain.Status.ALIVE;
 import static common.domain.member.QMember.member;
 import static common.domain.schedule.QSchedule.schedule;
@@ -181,15 +185,23 @@ public class ScheduleQueryRepositoryCustomImpl implements ScheduleQueryRepositor
     }
 
     @Override
-    public List<ScheduleMemberResDto> getScheduleMembersWithMember(Long scheduleId) {
+    public List<ScheduleMemberResDto> getScheduleMembersWithBettingInfo(Long memberId, Long scheduleId) {
+        QScheduleMember subScheduleMember = new QScheduleMember("subScheduleMember");
+
         return query
                 .select(Projections.constructor(ScheduleMemberResDto.class,
                         member.id, member.nickname,
                         Projections.constructor(MemberProfileResDto.class,
                                 member.profile.profileType, member.profile.profileImg, member.profile.profileCharacter, member.profile.profileBackground),
-                        member.point))
+                        member.point, betting.betee.id))
                 .from(scheduleMember)
-                .innerJoin(scheduleMember.member, member)
+                .innerJoin(member).on(member.id.eq(scheduleMember.member.id))
+                .leftJoin(betting).on(betting.betee.id.eq(scheduleMember.id),
+                        betting.bettor.id.eq(
+                                JPAExpressions.select(subScheduleMember.id)
+                                        .from(subScheduleMember)
+                                        .where(subScheduleMember.member.id.eq(memberId))
+                        ))
                 .where(scheduleMember.schedule.id.eq(scheduleId),
                         scheduleMember.status.eq(ALIVE))
                 .orderBy(scheduleMember.createdAt.asc())

--- a/aiku/aiku-main/src/main/java/aiku_main/service/ScheduleService.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/service/ScheduleService.java
@@ -219,7 +219,7 @@ public class ScheduleService {
         checkScheduleMember(memberId, scheduleId, true);
 
         //서비스 로직
-        List<ScheduleMemberResDto> membersDtoList = scheduleQueryRepository.getScheduleMembersWithMember(scheduleId);
+        List<ScheduleMemberResDto> membersDtoList = scheduleQueryRepository.getScheduleMembersWithBettingInfo(memberId, scheduleId);
 
         return new ScheduleDetailResDto(schedule, membersDtoList);
     }

--- a/aiku/aiku-main/src/test/java/aiku_main/integration_test/ScheduleServiceIntegrationTest.java
+++ b/aiku/aiku-main/src/test/java/aiku_main/integration_test/ScheduleServiceIntegrationTest.java
@@ -417,6 +417,7 @@ public class ScheduleServiceIntegrationTest {
         List<ScheduleMemberResDto> scheduleMembers = resultDto.getMembers();
         assertThat(scheduleMembers.size()).isEqualTo(3);
         assertThat(scheduleMembers).extracting("memberId").containsExactly(member1.getId(), member2.getId(), member3.getId());
+        assertThat(scheduleMembers).extracting("isOwner").containsExactly(true, false, false);
     }
 
     @Test

--- a/aiku/aiku-main/src/test/java/aiku_main/integration_test/ScheduleServiceIntegrationTest.java
+++ b/aiku/aiku-main/src/test/java/aiku_main/integration_test/ScheduleServiceIntegrationTest.java
@@ -15,6 +15,7 @@ import common.domain.member.Member;
 import common.domain.schedule.Schedule;
 import common.domain.schedule.ScheduleMember;
 import common.domain.team.Team;
+import common.domain.value_reference.ScheduleMemberValue;
 import common.domain.value_reference.TeamValue;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.AfterEach;
@@ -416,6 +417,36 @@ public class ScheduleServiceIntegrationTest {
         List<ScheduleMemberResDto> scheduleMembers = resultDto.getMembers();
         assertThat(scheduleMembers.size()).isEqualTo(3);
         assertThat(scheduleMembers).extracting("memberId").containsExactly(member1.getId(), member2.getId(), member3.getId());
+    }
+
+    @Test
+    void 스케줄_상세_조회_꼴찌_멤버_선택() {
+        //given
+        Team team = Team.create(member1, "team1");
+        team.addTeamMember(member2);
+        team.addTeamMember(member3);
+        team.addTeamMember(member4);
+        em.persist(team);
+
+        Schedule schedule = createSchedule(member1, team, 100);
+        schedule.addScheduleMember(member2, false, 0);
+        schedule.addScheduleMember(member3, false, 100);
+        em.persist(schedule);
+
+        ScheduleMember scheduleMember1 = scheduleQueryRepository.findScheduleMember(member1.getId(), schedule.getId()).orElseThrow();
+        ScheduleMember scheduleMember2 = scheduleQueryRepository.findScheduleMember(member2.getId(), schedule.getId()).orElseThrow();
+        Betting betting = Betting.create(new ScheduleMemberValue(scheduleMember1), new ScheduleMemberValue(scheduleMember2), 100);
+        em.persist(betting);
+
+        //when
+        ScheduleDetailResDto resultDto = scheduleService.getScheduleDetail(member1.getId(), team.getId(), schedule.getId());
+
+        //then
+        assertThat(resultDto.getScheduleId()).isEqualTo(schedule.getId());
+
+        List<ScheduleMemberResDto> scheduleMembers = resultDto.getMembers();
+        assertThat(scheduleMembers).extracting("isBetee").containsExactly(false, true, false);
+
     }
 
     @Test

--- a/aiku/aiku-main/src/test/java/aiku_main/integration_test/TeamServiceIntegrationTest.java
+++ b/aiku/aiku-main/src/test/java/aiku_main/integration_test/TeamServiceIntegrationTest.java
@@ -328,6 +328,53 @@ public class TeamServiceIntegrationTest {
     }
 
     @Test
+    void 이벤트핸들러_그룹_지각_분석_이전결과존재() throws JsonProcessingException {
+        //given
+        Team team = Team.create(member1, "team");
+        team.addTeamMember(member2);
+        team.addTeamMember(member3);
+        em.persist(team);
+
+        Schedule schedule1 = Schedule.create(member1, new TeamValue(team), "schedule1",
+                LocalDateTime.now().minusDays(1), new Location("loc", 1.0, 1.0), 0);
+        schedule1.addScheduleMember(member2, false, 0);
+        schedule1.addScheduleMember(member3, false, 0);
+        em.persist(schedule1);
+
+        schedule1.arriveScheduleMember(schedule1.getScheduleMembers().get(0), LocalDateTime.now().minusDays(1).plusMinutes(20));
+        schedule1.arriveScheduleMember(schedule1.getScheduleMembers().get(1), LocalDateTime.now().minusDays(1).plusMinutes(10));
+        schedule1.arriveScheduleMember(schedule1.getScheduleMembers().get(2), LocalDateTime.now().minusDays(1).plusMinutes(5));
+        schedule1.setTerm(schedule1.getScheduleTime().plusMinutes(30));
+
+        teamService.analyzeLateTimeResult(schedule1.getId());
+
+        Schedule schedule2 = Schedule.create(member1, new TeamValue(team), "schedule2",
+                LocalDateTime.now().minusDays(1), new Location("loc", 1.0, 1.0), 0);
+        schedule2.addScheduleMember(member2, false, 0);
+        schedule2.addScheduleMember(member3, false, 0);
+        em.persist(schedule2);
+
+        schedule2.arriveScheduleMember(schedule2.getScheduleMembers().get(0), LocalDateTime.now().minusDays(1).plusMinutes(10));
+        schedule2.arriveScheduleMember(schedule2.getScheduleMembers().get(1), LocalDateTime.now().minusDays(1).plusMinutes(50));
+        schedule2.arriveScheduleMember(schedule2.getScheduleMembers().get(2), LocalDateTime.now().minusDays(1).plusMinutes(100));
+        schedule2.setTerm(schedule2.getScheduleTime().plusMinutes(30));
+
+        //when
+        teamService.analyzeLateTimeResult(schedule1.getId());
+        em.flush();
+        em.clear();
+
+        //then
+        Team findTeam = teamQueryRepository.findById(team.getId()).orElse(null);
+        assertThat(findTeam).isNotNull();
+
+        TeamLateTimeResult result = objectMapper.readValue(findTeam.getTeamResult().getLateTimeResult(), TeamLateTimeResult.class);
+        List<TeamResultMember> lateMemberRanking = result.getMembers();
+        assertThat(lateMemberRanking).extracting("previousRank").containsExactly(3, 2, 1);
+        assertThat(lateMemberRanking).extracting("rank").containsExactly(1, 2, 3);
+    }
+
+    @Test
     void 이벤트핸들러_베팅_분석() throws JsonProcessingException {
         //given
         Team team = Team.create(member1, "team");

--- a/aiku/aiku-main/src/test/java/aiku_main/integration_test/TeamServiceIntegrationTest.java
+++ b/aiku/aiku-main/src/test/java/aiku_main/integration_test/TeamServiceIntegrationTest.java
@@ -427,4 +427,54 @@ public class TeamServiceIntegrationTest {
         assertThat(teamResultMembers.size()).isEqualTo(3);
         assertThat(teamResultMembers).extracting("memberId").containsExactly(member3.getId(), member2.getId(), member1.getId());
     }
+
+    @Test
+    void 이벤트핸들러_베팅_분석_이전결과존재() throws JsonProcessingException {
+        //given
+        Team team = Team.create(member1, "team");
+        team.addTeamMember(member2);
+        team.addTeamMember(member3);
+        em.persist(team);
+
+        Schedule schedule1 = Schedule.create(member1, new TeamValue(team), "schedule1",
+                LocalDateTime.now().minusDays(1), new Location("loc", 1.0, 1.0), 0);
+        schedule1.addScheduleMember(member2, false, 0);
+        schedule1.addScheduleMember(member3, false, 0);
+        em.persist(schedule1);
+
+        Schedule schedule2 = Schedule.create(member1, new TeamValue(team), "schedule2",
+                LocalDateTime.now().minusDays(1), new Location("loc", 1.0, 1.0), 0);
+        schedule2.addScheduleMember(member2, false, 0);
+        schedule2.addScheduleMember(member3, false, 0);
+        em.persist(schedule2);
+
+        Betting betting1 = Betting.create(new ScheduleMemberValue(schedule1.getScheduleMembers().get(0)), new ScheduleMemberValue(schedule1.getScheduleMembers().get(1)), 100);
+        betting1.setWin(100);
+        em.persist(betting1);
+
+        Betting betting2 = Betting.create(new ScheduleMemberValue(schedule1.getScheduleMembers().get(1)), new ScheduleMemberValue(schedule1.getScheduleMembers().get(2)), 100);
+        betting2.setLose();
+        em.persist(betting2);
+
+        teamService.analyzeBettingResult(schedule1.getId());
+
+        Betting betting4 = Betting.create(new ScheduleMemberValue(schedule2.getScheduleMembers().get(0)), new ScheduleMemberValue(schedule2.getScheduleMembers().get(1)), 100);
+        betting4.setWin(100);
+        em.persist(betting4);
+
+        Betting betting5 = Betting.create(new ScheduleMemberValue(schedule2.getScheduleMembers().get(2)), new ScheduleMemberValue(schedule2.getScheduleMembers().get(1)), 100);
+        betting5.setWin(100);
+        em.persist(betting5);
+
+        //when
+        teamService.analyzeBettingResult(schedule1.getId());
+
+        //then
+        Team findTeam = teamQueryRepository.findById(team.getId()).orElse(null);
+        assertThat(findTeam).isNotNull();
+        List<TeamResultMember> teamResultMembers = objectMapper.readValue(findTeam.getTeamResult().getTeamBettingResult(), TeamBettingResult.class)
+                .getMembers();
+        assertThat(teamResultMembers).extracting("rank").containsExactly(1, 2, 3);
+        assertThat(teamResultMembers).extracting("previousRank").containsExactly(1, -1, 2);
+    }
 }

--- a/aiku/aiku-main/src/test/java/aiku_main/service/ScheduleServiceTest.java
+++ b/aiku/aiku-main/src/test/java/aiku_main/service/ScheduleServiceTest.java
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.lang.Nullable;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -82,7 +81,7 @@ class ScheduleServiceTest {
 
         when(scheduleQueryRepository.existScheduleMember(any(), any())).thenReturn(true);
         when(scheduleQueryRepository.findByIdAndStatus(nullable(Long.class), any())).thenReturn(Optional.of(schedule));
-        when(scheduleQueryRepository.getScheduleMembersWithMember(nullable(Long.class))).thenReturn(null);
+        when(scheduleQueryRepository.getScheduleMembersWithBettingInfo(nullable(Long.class), nullable(Long.class))).thenReturn(null);
 
         //when
         ScheduleDetailResDto result = scheduleService.getScheduleDetail(member1.getId(), null, null);


### PR DESCRIPTION
## 관련 이슈 번호

- #93 

<br />

## 작업 사항

- 스케줄 상세 조회의 멤버 리스트에 방장, 꼴찌 선택 정보 추가
- 그룹 지각 분석에 순위 상승인지 하락인지를 알기 위한 이전 랭크와 현재 랭크 필드 추가 및 로직 반영
- 그룹 베팅 분석에 순위 상승인지 하락인지를 알기 위한 이전 랭크와 현재 랭크 필드 추가 및 로직 반영

<br />

## 기타 사항
<br />
