### PR TITLE
지정된 달에서 스케줄이 있는 날짜 반환 기능 개발 및 그 외 기능 보강

### DIFF
--- a/aiku/aiku-main/src/main/java/aiku_main/controller/ScheduleController.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/controller/ScheduleController.java
@@ -9,6 +9,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
+import java.util.List;
+
 @Slf4j
 @RequestMapping({"/groups/{groupId}/schedules", "/member"})
 @RequiredArgsConstructor
@@ -106,6 +109,14 @@ public class ScheduleController {
                                                          @PathVariable Long groupId,
                                                          @PathVariable Long scheduleId){
         String result = scheduleService.getScheduleRacingResult(memberId, groupId, scheduleId);
+
+        return new BaseResponse<>(result);
+    }
+
+    @GetMapping("/schedules/dates")
+    public BaseResponse<SimpleResDto<List<LocalDate>>> getScheduleDates(@RequestHeader(name = "Access-Member-Id") Long memberId,
+                                                                        @ModelAttribute MonthDto monthDto){
+        SimpleResDto<List<LocalDate>> result = scheduleService.getScheduleDatesInMonth(memberId, monthDto);
 
         return new BaseResponse<>(result);
     }

--- a/aiku/aiku-main/src/main/java/aiku_main/controller/ScheduleController.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/controller/ScheduleController.java
@@ -115,7 +115,7 @@ public class ScheduleController {
 
     @GetMapping("/schedules/dates")
     public BaseResponse<SimpleResDto<List<LocalDate>>> getScheduleDates(@RequestHeader(name = "Access-Member-Id") Long memberId,
-                                                                        @ModelAttribute MonthDto monthDto){
+                                                                        @ModelAttribute @Valid MonthDto monthDto){
         SimpleResDto<List<LocalDate>> result = scheduleService.getScheduleDatesInMonth(memberId, monthDto);
 
         return new BaseResponse<>(result);

--- a/aiku/aiku-main/src/main/java/aiku_main/dto/MonthDto.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/dto/MonthDto.java
@@ -5,7 +5,9 @@ import jakarta.validation.constraints.Min;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@Setter
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor

--- a/aiku/aiku-main/src/main/java/aiku_main/dto/MonthDto.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/dto/MonthDto.java
@@ -1,0 +1,20 @@
+package aiku_main.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class MonthDto {
+
+    @Min(2024)
+    private int year;
+
+    @Min(1)
+    @Max(12)
+    private int month;
+}

--- a/aiku/aiku-main/src/main/java/aiku_main/dto/ScheduleDetailResDto.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/dto/ScheduleDetailResDto.java
@@ -3,6 +3,7 @@ package aiku_main.dto;
 import common.domain.schedule.Schedule;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
@@ -10,12 +11,14 @@ public class ScheduleDetailResDto {
 
     private Long scheduleId;
     private String scheduleName;
+    private LocalDateTime scheduleTime;
     private LocationDto location;
     List<ScheduleMemberResDto> members;
 
     public ScheduleDetailResDto(Schedule schedule, List<ScheduleMemberResDto> members) {
         this.scheduleId = schedule.getId();
         this.scheduleName = schedule.getScheduleName();
+        this.scheduleTime = schedule.getScheduleTime();
         this.location = new LocationDto(schedule.getLocation());
         this.members = members;
     }

--- a/aiku/aiku-main/src/main/java/aiku_main/dto/SearchDateCond.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/dto/SearchDateCond.java
@@ -3,9 +3,11 @@ package aiku_main.dto;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.time.LocalDateTime;
 
+@Setter
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor

--- a/aiku/aiku-main/src/main/java/aiku_main/dto/SimpleResDto.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/dto/SimpleResDto.java
@@ -1,0 +1,11 @@
+package aiku_main.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SimpleResDto<T> {
+
+    private T data;
+}

--- a/aiku/aiku-main/src/main/java/aiku_main/repository/ScheduleQueryRepositoryCustom.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/repository/ScheduleQueryRepositoryCustom.java
@@ -1,14 +1,12 @@
 package aiku_main.repository;
 
 import aiku_main.application_event.domain.ScheduleArrivalMember;
-import aiku_main.dto.MemberScheduleListEachResDto;
-import aiku_main.dto.ScheduleMemberResDto;
-import aiku_main.dto.SearchDateCond;
-import aiku_main.dto.TeamScheduleListEachResDto;
+import aiku_main.dto.*;
 import common.domain.ExecStatus;
 import common.domain.schedule.Schedule;
 import common.domain.schedule.ScheduleMember;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -32,6 +30,7 @@ public interface ScheduleQueryRepositoryCustom {
     int findPointAmountOfLatePaidScheduleMember(Long scheduleId);
     int countTeamScheduleByScheduleStatus(Long teamId, ExecStatus scheduleStatus, SearchDateCond dateCond);
     int countMemberScheduleByScheduleStatus(Long memberId, ExecStatus scheduleStatus, SearchDateCond dateCond);
+    List<LocalDateTime> findScheduleDatesInMonth(Long memberId, int year, int month);
 
     List<ScheduleMemberResDto> getScheduleMembersWithBettingInfo(Long memberId, Long scheduleId);
     List<TeamScheduleListEachResDto> getTeamSchedules(Long teamId, Long memberId, SearchDateCond dateCond, int page);

--- a/aiku/aiku-main/src/main/java/aiku_main/repository/ScheduleQueryRepositoryCustom.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/repository/ScheduleQueryRepositoryCustom.java
@@ -26,6 +26,7 @@ public interface ScheduleQueryRepositoryCustom {
     boolean isScheduleOwner(Long memberId, Long scheduleId);
     boolean existScheduleMember(Long memberId, Long scheduleId);
     boolean existPaidScheduleMember(Long memberId, Long scheduleId);
+    boolean existRunScheduleOfMemberInTeam(Long memberId, Long teamId);
     Long countOfScheduleMembers(Long scheduleId);
     int findPointAmountOfLatePaidScheduleMember(Long scheduleId);
     int countTeamScheduleByScheduleStatus(Long teamId, ExecStatus scheduleStatus, SearchDateCond dateCond);

--- a/aiku/aiku-main/src/main/java/aiku_main/repository/ScheduleQueryRepositoryCustomImpl.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/repository/ScheduleQueryRepositoryCustomImpl.java
@@ -8,13 +8,13 @@ import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import common.domain.ExecStatus;
-import common.domain.QBetting;
 import common.domain.schedule.QScheduleMember;
 import common.domain.schedule.Schedule;
 import common.domain.schedule.ScheduleMember;
 import lombok.RequiredArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.time.YearMonth;
 import java.util.List;
 import java.util.Optional;
 
@@ -301,6 +301,23 @@ public class ScheduleQueryRepositoryCustomImpl implements ScheduleQueryRepositor
                         scheduleTimeLoe(dateCond.getEndDate()))
                 .fetchFirst()
                 .intValue();
+    }
+
+    @Override
+    public List<LocalDateTime> findScheduleDatesInMonth(Long memberId, int year, int month) {
+        YearMonth yearMonth = YearMonth.of(year, month);
+        LocalDateTime startOfMonth = yearMonth.atDay(1).atStartOfDay();
+        LocalDateTime endOfMonth = yearMonth.atEndOfMonth().atTime(23, 59, 59);
+
+        return query
+                .select(schedule.scheduleTime)
+                .from(scheduleMember)
+                .innerJoin(scheduleMember.member, member)
+                .innerJoin(scheduleMember.schedule, schedule)
+                .where(member.id.eq(memberId),
+                        schedule.scheduleTime.between(startOfMonth, endOfMonth))
+                .orderBy(schedule.scheduleTime.asc())
+                .fetch();
     }
 
     @Override

--- a/aiku/aiku-main/src/main/java/aiku_main/repository/ScheduleQueryRepositoryCustomImpl.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/repository/ScheduleQueryRepositoryCustomImpl.java
@@ -18,6 +18,7 @@ import java.time.YearMonth;
 import java.util.List;
 import java.util.Optional;
 
+import static common.domain.ExecStatus.RUN;
 import static common.domain.ExecStatus.WAIT;
 import static common.domain.QBetting.betting;
 import static common.domain.Status.ALIVE;
@@ -82,6 +83,23 @@ public class ScheduleQueryRepositoryCustomImpl implements ScheduleQueryRepositor
                 .where(scheduleMember.member.id.eq(memberId),
                         scheduleMember.schedule.id.eq(scheduleId),
                         scheduleMember.pointAmount.isNotNull(),
+                        scheduleMember.status.eq(ALIVE))
+                .fetchOne();
+
+        return count != null && count > 0;
+    }
+
+    @Override
+    public boolean existRunScheduleOfMemberInTeam(Long memberId, Long teamId) {
+        Long count = query
+                .select(schedule.count())
+                .from(scheduleMember)
+                .innerJoin(scheduleMember.member, member)
+                .innerJoin(scheduleMember.schedule, schedule)
+                .where(member.id.eq(memberId),
+                        schedule.team.id.eq(teamId),
+                        schedule.scheduleStatus.eq(RUN),
+                        schedule.status.eq(ALIVE),
                         scheduleMember.status.eq(ALIVE))
                 .fetchOne();
 
@@ -315,7 +333,9 @@ public class ScheduleQueryRepositoryCustomImpl implements ScheduleQueryRepositor
                 .innerJoin(scheduleMember.member, member)
                 .innerJoin(scheduleMember.schedule, schedule)
                 .where(member.id.eq(memberId),
-                        schedule.scheduleTime.between(startOfMonth, endOfMonth))
+                        schedule.scheduleTime.between(startOfMonth, endOfMonth),
+                        schedule.status.eq(ALIVE),
+                        scheduleMember.status.eq(ALIVE))
                 .orderBy(schedule.scheduleTime.asc())
                 .fetch();
     }

--- a/aiku/aiku-main/src/main/java/aiku_main/service/ScheduleService.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/service/ScheduleService.java
@@ -33,6 +33,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -278,6 +279,16 @@ public class ScheduleService {
         return schedule.getScheduleResult() == null? null : schedule.getScheduleResult().getScheduleRacingResult();
     }
 
+    public SimpleResDto<List<LocalDate>> getScheduleDatesInMonth(Long memberId, MonthDto monthDto) {
+        List<LocalDate> scheduleTimeList = scheduleQueryRepository.findScheduleDatesInMonth(memberId, monthDto.getYear(), monthDto.getMonth())
+                .stream()
+                .map(dateTime -> dateTime.toLocalDate())
+                .distinct()
+                .toList();
+
+        return new SimpleResDto<>(scheduleTimeList);
+    }
+
     //== 이벤트 핸들러 ==
     @Transactional
     public void exitAllScheduleInTeam(Long memberId, Long teamId) {
@@ -436,4 +447,5 @@ public class ScheduleService {
             throw new ScheduleException(FORBIDDEN_SCHEDULE_UPDATE_TIME);
         }
     }
+
 }

--- a/aiku/aiku-main/src/main/java/aiku_main/service/TeamService.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/service/TeamService.java
@@ -73,6 +73,7 @@ public class TeamService {
         Member member = findMember(memberId);
         Team team = findTeamById(teamId);
         checkTeamMember(member.getId(), teamId, true);
+        checkHasRunSchedule(member.getId(), teamId);
 
         //서비스 로직
         Long teamMemberCount = teamQueryRepository.countOfAliveTeamMember(teamId);
@@ -318,6 +319,12 @@ public class TeamService {
             }else {
                 throw new TeamException(ALREADY_IN_TEAM);
             }
+        }
+    }
+
+    private void checkHasRunSchedule(Long memberId, Long teamId) {
+        if(scheduleQueryRepository.existRunScheduleOfMemberInTeam(memberId, teamId)){
+            throw new TeamException(CAN_NOT_EXIT);
         }
     }
 }

--- a/aiku/aiku-main/src/test/java/aiku_main/controller/ScheduleControllerTest.java
+++ b/aiku/aiku-main/src/test/java/aiku_main/controller/ScheduleControllerTest.java
@@ -1,9 +1,6 @@
 package aiku_main.controller;
 
-import aiku_main.dto.LocationDto;
-import aiku_main.dto.ScheduleAddDto;
-import aiku_main.dto.ScheduleEnterDto;
-import aiku_main.dto.ScheduleUpdateDto;
+import aiku_main.dto.*;
 import aiku_main.service.ScheduleService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -19,8 +16,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import java.time.LocalDateTime;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith(MockitoExtension.class)
@@ -190,6 +186,24 @@ class ScheduleControllerTest {
                         .header("Access-Member-Id", 1L)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(new ScheduleEnterDto(3))))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void getScheduleDates() throws Exception {
+        mockMvc.perform(get("/member/schedules/dates")
+                        .header("Access-Member-Id", 1L)
+                        .param("year", "2025")
+                        .param("month", "11"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void getScheduleDatesWithFaultDate() throws Exception {
+        mockMvc.perform(get("/member/schedules/dates")
+                        .header("Access-Member-Id", 1L)
+                        .param("year", "2024")
+                        .param("month", "13"))
                 .andExpect(status().isBadRequest());
     }
 }

--- a/aiku/aiku-main/src/test/java/aiku_main/integration_test/ScheduleServiceIntegrationTest.java
+++ b/aiku/aiku-main/src/test/java/aiku_main/integration_test/ScheduleServiceIntegrationTest.java
@@ -28,6 +28,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Random;
@@ -621,6 +622,35 @@ public class ScheduleServiceIntegrationTest {
         assertThat(schedules).extracting("groupId").containsExactly(teamB.getId(), teamB.getId());
         assertThat(schedules).extracting("scheduleId").containsExactly(scheduleB2.getId(), scheduleB1.getId());
         assertThat(schedules).extracting("memberSize").containsExactly(1, 1);
+    }
+    
+    @Test
+    void 멤버_지정된달의_스케줄있는_날짜_조회() {
+        //given
+        Team team1 = Team.create(member1, "team1");
+        em.persist(team1);
+
+        Team team2 = Team.create(member1, "team2");
+        em.persist(team2);
+
+        LocalDateTime now = LocalDateTime.now();
+        Schedule schedule1 = Schedule.create(member1, new TeamValue(team1), "sche1", now.plusDays(1), new Location("loc", 1.0, 1.0), 0);
+        em.persist(schedule1);
+
+        Schedule schedule2 = Schedule.create(member1, new TeamValue(team1), "sche2", now.plusDays(1), new Location("loc", 1.0, 1.0), 0);
+        em.persist(schedule2);
+
+        Schedule schedule3 = Schedule.create(member1, new TeamValue(team1), "sche3", now.plusDays(2), new Location("loc", 1.0, 1.0), 0);
+        em.persist(schedule3);
+        
+        //when
+        List<LocalDate> result = scheduleService.getScheduleDatesInMonth(member1.getId(), new MonthDto(now.getYear(), now.getMonth().getValue()))
+                .getData();
+
+        //then
+        assertThat(result.size()).isEqualTo(2);
+        assertThat(result).contains(LocalDate.of(now.getYear(), now.getMonth(), now.getDayOfMonth() + 1),
+                LocalDate.of(now.getYear(), now.getMonth(), now.getDayOfMonth() + 2));
     }
 
     @Test

--- a/aiku/aiku-main/src/test/java/aiku_main/integration_test/TeamServiceIntegrationTest.java
+++ b/aiku/aiku-main/src/test/java/aiku_main/integration_test/TeamServiceIntegrationTest.java
@@ -72,9 +72,6 @@ public class TeamServiceIntegrationTest {
         TeamAddDto teamDto = new TeamAddDto("group1");
         Long teamId = teamService.addTeam(member1.getId(), teamDto);
 
-        em.flush();
-        em.clear();
-
         //then
         Team team = teamQueryRepository.findById(teamId).get();
         assertThat(team.getTeamName()).isEqualTo(teamDto.getGroupName());
@@ -89,9 +86,6 @@ public class TeamServiceIntegrationTest {
         //given
         Team team = Team.create(member1, "team1");
         em.persist(team);
-
-        em.flush();
-        em.clear();
 
         //when
         Long teamId = teamService.enterTeam(member2.getId(), team.getId());
@@ -108,9 +102,6 @@ public class TeamServiceIntegrationTest {
         team.addTeamMember(member2);
         em.persist(team);
 
-        em.flush();
-        em.clear();
-
         //when
         assertThatThrownBy(() -> teamService.enterTeam(member2.getId(), team.getId())).isInstanceOf(TeamException.class);
     }
@@ -123,13 +114,8 @@ public class TeamServiceIntegrationTest {
         team.addTeamMember(member2);
         em.persist(team);
 
-        em.flush();
-        em.clear();
-
         //when
         teamService.exitTeam(member2.getId(), team.getId());
-        em.flush();
-        em.clear();
 
         //then
         Team findTeam = teamQueryRepository.findById(team.getId()).orElse(null);
@@ -146,9 +132,6 @@ public class TeamServiceIntegrationTest {
         //given
         Team team = Team.create(member1, "team1");
         em.persist(team);
-
-        em.flush();
-        em.clear();
 
         //when
         assertThatThrownBy(() -> teamService.exitTeam(member2.getId(), team.getId())).isInstanceOf(TeamException.class);
@@ -177,8 +160,6 @@ public class TeamServiceIntegrationTest {
         em.persist(team);
 
         teamService.exitTeam(member2.getId(), team.getId());
-        em.flush();
-        em.clear();
 
         //when
         assertThatThrownBy(() -> teamService.exitTeam(member2.getId(), team.getId())).isInstanceOf(TeamException.class);
@@ -190,13 +171,8 @@ public class TeamServiceIntegrationTest {
         Team team = Team.create(member1, "team1");
         em.persist(team);
 
-        em.flush();
-        em.clear();
-
         //when
         teamService.exitTeam(member1.getId(), team.getId());
-        em.flush();
-        em.clear();
 
         //then
         Team findTeam = teamQueryRepository.findById(team.getId()).orElse(null);
@@ -210,9 +186,6 @@ public class TeamServiceIntegrationTest {
         Team team = Team.create(member1, "team1");
         team.addTeamMember(member2);
         em.persist(team);
-
-        em.flush();
-        em.clear();
 
         //when
         TeamDetailResDto result = teamService.getTeamDetail(member1.getId(), team.getId());
@@ -231,9 +204,6 @@ public class TeamServiceIntegrationTest {
         //given
         Team team = Team.create(member1, "team1");
         em.persist(team);
-
-        em.flush();
-        em.clear();
 
         //when
         assertThatThrownBy(() -> teamService.getTeamDetail(member2.getId(), team.getId())).isInstanceOf(TeamException.class);
@@ -280,9 +250,6 @@ public class TeamServiceIntegrationTest {
         scheduleC1.setTerm(LocalDateTime.now());
         em.persist(scheduleC1);
 
-        em.flush();
-        em.clear();
-
         //when
         int page = 1;
         DataResDto<List<TeamEachListResDto>> result = teamService.getTeamList(member1.getId(), page);
@@ -324,13 +291,8 @@ public class TeamServiceIntegrationTest {
         schedule2.arriveScheduleMember(schedule2.getScheduleMembers().get(2), LocalDateTime.now().minusDays(1).minusMinutes(30));
         schedule2.setTerm(schedule2.getScheduleTime().plusMinutes(30));
 
-        em.flush();
-        em.clear();
-
         //when
         teamService.analyzeLateTimeResult(schedule1.getId());
-        em.flush();
-        em.clear();
 
         //then
         Team findTeam = teamQueryRepository.findById(team.getId()).orElse(null);
@@ -376,8 +338,6 @@ public class TeamServiceIntegrationTest {
 
         //when
         teamService.analyzeLateTimeResult(schedule1.getId());
-        em.flush();
-        em.clear();
 
         //then
         Team findTeam = teamQueryRepository.findById(team.getId()).orElse(null);
@@ -431,8 +391,6 @@ public class TeamServiceIntegrationTest {
 
         //when
         teamService.analyzeBettingResult(schedule1.getId());
-        em.flush();
-        em.clear();
 
         //then
         Team findTeam = teamQueryRepository.findById(team.getId()).orElse(null);
@@ -535,8 +493,6 @@ public class TeamServiceIntegrationTest {
 
         //when
         teamService.analyzeRacingResult(schedule1.getId());
-        em.flush();
-        em.clear();
 
         //then
         Team findTeam = teamQueryRepository.findById(team.getId()).orElse(null);
@@ -582,9 +538,6 @@ public class TeamServiceIntegrationTest {
         team.addTeamMember(member4);
         schedule2.addScheduleMember(member4, false, 0);
 
-        em.flush();
-        em.clear();
-
         Racing racing3 = Racing.create(schedule2.getScheduleMembers().get(0).getId(), schedule2.getScheduleMembers().get(1).getId(), 20);
         racing3.termRacing(schedule2.getScheduleMembers().get(0).getId());
         em.persist(racing3);
@@ -599,8 +552,6 @@ public class TeamServiceIntegrationTest {
 
         //when
         teamService.analyzeRacingResult(schedule1.getId());
-        em.flush();
-        em.clear();
 
         //then
         Team findTeam = teamQueryRepository.findById(team.getId()).orElse(null);

--- a/aiku/aiku-main/src/test/java/aiku_main/integration_test/TeamServiceIntegrationTest.java
+++ b/aiku/aiku-main/src/test/java/aiku_main/integration_test/TeamServiceIntegrationTest.java
@@ -155,6 +155,20 @@ public class TeamServiceIntegrationTest {
     }
 
     @Test
+    void 그룹_퇴장_실행중인스케줄O() {
+        //given
+        Team team = Team.create(member1, "team1");
+        em.persist(team);
+
+        Schedule schedule = Schedule.create(member1, new TeamValue(team), "sche1", LocalDateTime.now().plusDays(1), new Location("loc", 1.0, 1.0), 0);
+        schedule.setRun();
+        em.persist(schedule);
+
+        //when
+        assertThatThrownBy(() -> teamService.exitTeam(member1.getId(), team.getId())).isInstanceOf(TeamException.class);
+    }
+
+    @Test
     void 그룹_퇴장_중복() {
         //given
         Team team = Team.create(member1, "team1");


### PR DESCRIPTION
## 관련 이슈 번호

- #98 

<br />

## 작업 사항

- 지정된 달에서 스케줄이 있는 날짜 반환 기능 개발 및 테스트
- 스케줄 상세 조회에 스케줄 시간 필드 추가
- 그룹 퇴장시 실행중인 스케줄이 있을때를 검증하는 로직 추가

<br />

## 기타 사항

- 컨트롤러 테스트 중 @ModelAttribute로 QueryParameter를 매핑할때 Setter가 없으면 필드가 바인딩되지 않는 문제점 발견. 기존에는 전체 생성자 있으면 바인딩 되는것으로 알고 있는데 이에 대한 확인 필요

<br />
