### PR TITLE
영속성 관리 문제로 인한 테스트 실패 해결

### DIFF
--- a/aiku/aiku-main/src/test/java/aiku_main/integration_test/TeamServiceIntegrationTest.java
+++ b/aiku/aiku-main/src/test/java/aiku_main/integration_test/TeamServiceIntegrationTest.java
@@ -538,6 +538,9 @@ public class TeamServiceIntegrationTest {
         team.addTeamMember(member4);
         schedule2.addScheduleMember(member4, false, 0);
 
+        em.flush();
+        em.clear();
+
         Racing racing3 = Racing.create(schedule2.getScheduleMembers().get(0).getId(), schedule2.getScheduleMembers().get(1).getId(), 20);
         racing3.termRacing(schedule2.getScheduleMembers().get(0).getId());
         em.persist(racing3);
@@ -556,6 +559,7 @@ public class TeamServiceIntegrationTest {
         //then
         Team findTeam = teamQueryRepository.findById(team.getId()).orElse(null);
         assertThat(findTeam).isNotNull();
+        System.out.println(findTeam.getTeamResult().getTeamRacingResult());
         List<TeamResultMember> teamResultMembers = objectMapper.readValue(findTeam.getTeamResult().getTeamRacingResult(), TeamRacingResult.class)
                 .getMembers();
         assertThat(teamResultMembers).extracting("rank").containsExactly(1, 2, 3, 4);


### PR DESCRIPTION
## 관련 이슈 번호
<br />

## 작업 사항
<br />

- TeamServiceIntegrationTest.이벤트핸들러_레이싱_분석_이전결과존재() 에 영속 상태 초기화 코드 삽입

## 기타 사항
<br />
