### PR TITLE
/member/schedules의 하위 경로 라우팅 설정

### DIFF
--- a/aiku/aiku-gateway/src/main/resources/application.yml
+++ b/aiku/aiku-gateway/src/main/resources/application.yml
@@ -27,7 +27,7 @@ spring:
         - id: aiku-main
           uri: ${AIKU_MAIN_IP}
           predicates:
-            - Path=/login/sign-in,/users/**,/term,/groups/**,/schedules/**,/member/schedules
+            - Path=/login/sign-in,/users/**,/term,/groups/**,/schedules/**,/member/schedules/**
         - id: aiku-map
           uri: ${AIKU_MAP_IP}
           predicates:


### PR DESCRIPTION
## 관련 이슈 번호

- #104 

<br />

## 작업 사항

- main 서버로의 라우팅 경로를 /member/schedules/** 로 수정

<br />

## 기타 사항
<br />
