### PR TITLE
스케줄 종료 시 다른 서비스에서  ScheduleCloseEvent만 핸들링 할 수 있도록 변경

### DIFF
--- a/aiku/aiku-main/src/main/java/aiku_main/application_event/handler/BettingHandler.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/application_event/handler/BettingHandler.java
@@ -27,23 +27,6 @@ public class BettingHandler {
         bettingService.exitSchedule_deleteBettingForBetee(event.getMember().getId(), event.getScheduleMember().getId(), event.getSchedule().getId());
     }
 
-    @Order(3)
-    @Async
-    @EventListener
-    public void processBettingResult(ScheduleAutoCloseEvent event){
-        if(scheduleService.isScheduleAutoClosed(event.getSchedule().getId())) {
-            bettingService.processBettingResult(event.getSchedule().getId());
-        }
-    }
-
-    @Async
-    @EventListener
-    public void analyzeScheduleBettingResult(ScheduleAutoCloseEvent event){
-        if(scheduleService.isScheduleAutoClosed(event.getSchedule().getId())){
-            bettingService.analyzeScheduleBettingResult(event.getSchedule().getId());
-        }
-    }
-
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void processBettingResult(ScheduleCloseEvent event){

--- a/aiku/aiku-main/src/main/java/aiku_main/application_event/handler/ScheduleHandler.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/application_event/handler/ScheduleHandler.java
@@ -29,28 +29,10 @@ public class ScheduleHandler {
         scheduleService.openSchedule(event.getSchedule().getId());
     }
 
-    @Order(1)
     @Async
     @EventListener
     public void closeScheduleAuto(ScheduleAutoCloseEvent event){
         scheduleService.closeScheduleAuto(event.getSchedule().getId());
-    }
-
-    @Order(2)
-    @Async
-    @EventListener
-    public void processSchedulePoint(ScheduleAutoCloseEvent event){
-        if(scheduleService.isScheduleAutoClosed(event.getSchedule().getId())) {
-            scheduleService.processScheduleResultPoint(event.getSchedule().getId());
-        }
-    }
-
-    @Async
-    @EventListener
-    public void analyzeScheduleArrivalResult(ScheduleAutoCloseEvent event){
-        if(scheduleService.isScheduleAutoClosed(event.getSchedule().getId())) {
-            scheduleService.analyzeScheduleArrivalResult(event.getSchedule().getId());
-        }
     }
 
     @Async

--- a/aiku/aiku-main/src/main/java/aiku_main/service/ScheduleService.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/service/ScheduleService.java
@@ -330,6 +330,8 @@ public class ScheduleService {
         schedule.autoClose(notArriveScheduleMembers, autoCloseTime);
 
         sendMessageToScheduleMembers(schedule, null, null, AlarmMessageType.SCHEDULE_AUTO_CLOSE);
+
+        scheduleEventPublisher.publishScheduleCloseEvent(schedule);
     }
 
     @Transactional
@@ -369,10 +371,6 @@ public class ScheduleService {
         } catch (JsonProcessingException e) {
             throw new JsonParseException();
         } ;
-    }
-
-    public boolean isScheduleAutoClosed(Long scheduleId){
-        return scheduleQueryRepository.existsByIdAndIsAutoClose(scheduleId, true);
     }
 
     private Member findMember(Long memberId){


### PR DESCRIPTION
## 관련 이슈 번호

- #109 

<br />

## 작업 사항

- ScheduleAutoCloseEvent를 핸들링하는 과정에서 ScheduleCloseEvent publish, 다른 서비스에서는 ScheduleCloseEvent만 핸들링

<br />

## 기타 사항
<br />
