### PR TITLE
Team관련 기능 검증 및 보강, 리팩토링

### DIFF
--- a/aiku/aiku-common/src/main/java/common/domain/team/Team.java
+++ b/aiku/aiku-common/src/main/java/common/domain/team/Team.java
@@ -27,7 +27,7 @@ public class Team extends BaseTime {
     @OneToMany(mappedBy = "team", cascade = CascadeType.ALL)
     private List<TeamMember> teamMembers = new ArrayList<>();
 
-    @OneToOne(fetch = FetchType.EAGER, cascade = CascadeType.ALL)
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private TeamResult teamResult;
 
     @Enumerated(value = EnumType.STRING)

--- a/aiku/aiku-common/src/main/java/common/domain/team/TeamMember.java
+++ b/aiku/aiku-common/src/main/java/common/domain/team/TeamMember.java
@@ -14,7 +14,8 @@ import lombok.NoArgsConstructor;
 public class TeamMember extends BaseTime {
 
     @Column(name = "teamMemberId")
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
     private Long id;
 
     @JoinColumn(name = "teamId")
@@ -33,7 +34,6 @@ public class TeamMember extends BaseTime {
         this.member = member;
     }
 
-    //==편의 메서드==
     protected void setStatus(Status status) {
         this.status = status;
     }

--- a/aiku/aiku-common/src/main/java/common/domain/team/TeamResult.java
+++ b/aiku/aiku-common/src/main/java/common/domain/team/TeamResult.java
@@ -12,7 +12,8 @@ import lombok.NoArgsConstructor;
 public class TeamResult extends BaseTime {
 
     @Column(name = "teamResultId")
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
     private Long id;
 
     @JoinColumn(name = "teamId")
@@ -35,7 +36,6 @@ public class TeamResult extends BaseTime {
         this.team = team;
     }
 
-    //==편의 메서드==
     protected void setLateTimeResult(String lateTimeResult) {
         this.lateTimeResult = lateTimeResult;
     }

--- a/aiku/aiku-common/src/main/java/common/util/ObjectMapperUtil.java
+++ b/aiku/aiku-common/src/main/java/common/util/ObjectMapperUtil.java
@@ -1,4 +1,4 @@
-package aiku_main.util;
+package common.util;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/aiku/aiku-main/src/main/java/aiku_main/application_event/handler/TeamHandler.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/application_event/handler/TeamHandler.java
@@ -36,6 +36,6 @@ public class TeamHandler {
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void updateLateTimeResultOfExitMember(TeamExitEvent event) {
-        teamService.updateLateTimeResultOfExitMember(event.getMember().getId(), event.getTeam().getId());
+        teamService.updateTeamResultOfExitMember(event.getMember().getId(), event.getTeam().getId());
     }
 }

--- a/aiku/aiku-main/src/main/java/aiku_main/controller/ScheduleController.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/controller/ScheduleController.java
@@ -1,6 +1,7 @@
 package aiku_main.controller;
 
 import aiku_main.dto.*;
+import aiku_main.dto.team.TeamScheduleListResDto;
 import aiku_main.service.ScheduleService;
 import common.response.BaseResponse;
 import common.response.BaseResultDto;

--- a/aiku/aiku-main/src/main/java/aiku_main/controller/TeamController.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/controller/TeamController.java
@@ -3,7 +3,7 @@ package aiku_main.controller;
 import aiku_main.dto.DataResDto;
 import aiku_main.dto.team.TeamAddDto;
 import aiku_main.dto.team.TeamDetailResDto;
-import aiku_main.dto.team.TeamEachListResDto;
+import aiku_main.dto.team.TeamResDto;
 import aiku_main.service.TeamService;
 import common.response.BaseResponse;
 import jakarta.validation.Valid;
@@ -54,7 +54,7 @@ public class TeamController {
     @GetMapping
     public BaseResponse getGroupList(@RequestHeader(name = "Access-Member-Id") Long memberId,
                                      @RequestParam(defaultValue = "1") int page){
-        DataResDto<List<TeamEachListResDto>> result = teamService.getTeamList(memberId, page);
+        DataResDto<List<TeamResDto>> result = teamService.getTeamList(memberId, page);
 
         return new BaseResponse(result);
     }

--- a/aiku/aiku-main/src/main/java/aiku_main/controller/TeamController.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/controller/TeamController.java
@@ -1,9 +1,9 @@
 package aiku_main.controller;
 
 import aiku_main.dto.DataResDto;
-import aiku_main.dto.TeamAddDto;
-import aiku_main.dto.TeamDetailResDto;
-import aiku_main.dto.TeamEachListResDto;
+import aiku_main.dto.team.TeamAddDto;
+import aiku_main.dto.team.TeamDetailResDto;
+import aiku_main.dto.team.TeamEachListResDto;
 import aiku_main.service.TeamService;
 import common.response.BaseResponse;
 import jakarta.validation.Valid;
@@ -77,7 +77,7 @@ public class TeamController {
 
     @GetMapping("/{groupId}/analytics/racing")
     public BaseResponse getGroupRacingResult(@RequestHeader(name = "Access-Member-Id") Long memberId,
-                                              @PathVariable Long groupId){
+                                             @PathVariable Long groupId){
         String result = teamService.getTeamRacingResult(memberId, groupId);
 
         return new BaseResponse(result);

--- a/aiku/aiku-main/src/main/java/aiku_main/dto/team/TeamAddDto.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/dto/team/TeamAddDto.java
@@ -1,4 +1,4 @@
-package aiku_main.dto;
+package aiku_main.dto.team;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;

--- a/aiku/aiku-main/src/main/java/aiku_main/dto/team/TeamBettingResult.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/dto/team/TeamBettingResult.java
@@ -1,4 +1,4 @@
-package aiku_main.application_event.domain;
+package aiku_main.dto.team;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -7,10 +7,9 @@ import lombok.NoArgsConstructor;
 import java.util.List;
 
 @Getter
-@NoArgsConstructor
 @AllArgsConstructor
-public class TeamLateTimeResult {
-
+@NoArgsConstructor
+public class TeamBettingResult {
     private Long groupId;
     private List<TeamResultMember> members;
 }

--- a/aiku/aiku-main/src/main/java/aiku_main/dto/team/TeamBettingResult.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/dto/team/TeamBettingResult.java
@@ -10,6 +10,7 @@ import java.util.List;
 @AllArgsConstructor
 @NoArgsConstructor
 public class TeamBettingResult {
+
     private Long groupId;
-    private List<TeamResultMember> members;
+    private List<TeamMemberResult> members;
 }

--- a/aiku/aiku-main/src/main/java/aiku_main/dto/team/TeamDetailResDto.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/dto/team/TeamDetailResDto.java
@@ -1,4 +1,4 @@
-package aiku_main.dto;
+package aiku_main.dto.team;
 
 import common.domain.team.Team;
 import lombok.Getter;

--- a/aiku/aiku-main/src/main/java/aiku_main/dto/team/TeamDetailResDto.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/dto/team/TeamDetailResDto.java
@@ -1,9 +1,7 @@
 package aiku_main.dto.team;
 
-import common.domain.team.Team;
 import lombok.Getter;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Getter
@@ -11,15 +9,11 @@ public class TeamDetailResDto {
 
     private Long groupId;
     private String groupName;
-    private List<TeamMemberResDto> members = new ArrayList<>();
+    private List<TeamMemberResDto> members;
 
-    public TeamDetailResDto(Team team) {
-        this.groupId = team.getId();
-        this.groupName = team.getTeamName();
-
-        List<TeamMemberResDto> members = team.getTeamMembers().stream()
-                .map(TeamMemberResDto::new)
-                .toList();
+    public TeamDetailResDto(Long groupId, String groupName, List<TeamMemberResDto> members) {
+        this.groupId = groupId;
+        this.groupName = groupName;
         this.members = members;
     }
 }

--- a/aiku/aiku-main/src/main/java/aiku_main/dto/team/TeamEachListResDto.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/dto/team/TeamEachListResDto.java
@@ -1,4 +1,4 @@
-package aiku_main.dto;
+package aiku_main.dto.team;
 
 import com.querydsl.core.annotations.QueryProjection;
 import lombok.Getter;

--- a/aiku/aiku-main/src/main/java/aiku_main/dto/team/TeamLateTimeResult.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/dto/team/TeamLateTimeResult.java
@@ -1,4 +1,4 @@
-package aiku_main.application_event.domain;
+package aiku_main.dto.team;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -7,9 +7,10 @@ import lombok.NoArgsConstructor;
 import java.util.List;
 
 @Getter
-@AllArgsConstructor
 @NoArgsConstructor
-public class TeamRacingResult {
+@AllArgsConstructor
+public class TeamLateTimeResult {
+
     private Long groupId;
     private List<TeamResultMember> members;
 }

--- a/aiku/aiku-main/src/main/java/aiku_main/dto/team/TeamLateTimeResult.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/dto/team/TeamLateTimeResult.java
@@ -12,5 +12,5 @@ import java.util.List;
 public class TeamLateTimeResult {
 
     private Long groupId;
-    private List<TeamResultMember> members;
+    private List<TeamMemberResult> members;
 }

--- a/aiku/aiku-main/src/main/java/aiku_main/dto/team/TeamMemberResDto.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/dto/team/TeamMemberResDto.java
@@ -1,8 +1,7 @@
 package aiku_main.dto.team;
 
 import aiku_main.dto.MemberProfileResDto;
-import common.domain.member.Member;
-import common.domain.team.TeamMember;
+import com.querydsl.core.annotations.QueryProjection;
 import lombok.Getter;
 
 @Getter
@@ -12,10 +11,10 @@ public class TeamMemberResDto {
     private String nickname;
     private MemberProfileResDto memberProfile;
 
-    public TeamMemberResDto(TeamMember teamMember) {
-        Member member = teamMember.getMember();
-        this.memberId = member.getId();
-        this.nickname = member.getNickname();
-        this.memberProfile = new MemberProfileResDto(member.getProfile());
+    @QueryProjection
+    public TeamMemberResDto(Long memberId, String nickname, MemberProfileResDto memberProfile) {
+        this.memberId = memberId;
+        this.nickname = nickname;
+        this.memberProfile = memberProfile;
     }
 }

--- a/aiku/aiku-main/src/main/java/aiku_main/dto/team/TeamMemberResDto.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/dto/team/TeamMemberResDto.java
@@ -1,5 +1,6 @@
-package aiku_main.dto;
+package aiku_main.dto.team;
 
+import aiku_main.dto.MemberProfileResDto;
 import common.domain.member.Member;
 import common.domain.team.TeamMember;
 import lombok.Getter;

--- a/aiku/aiku-main/src/main/java/aiku_main/dto/team/TeamMemberResult.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/dto/team/TeamMemberResult.java
@@ -11,7 +11,7 @@ import static common.domain.Status.ALIVE;
 
 @Getter @Setter
 @NoArgsConstructor
-public class TeamResultMember {
+public class TeamMemberResult {
 
     private Long memberId;
     private String nickname;
@@ -22,7 +22,7 @@ public class TeamResultMember {
     private boolean isTeamMember;
 
     @QueryProjection
-    public TeamResultMember(Long memberId, String nickname, MemberProfileResDto memberProfile, int analysis, Status isTeamMember) {
+    public TeamMemberResult(Long memberId, String nickname, MemberProfileResDto memberProfile, int analysis, Status isTeamMember) {
         this.memberId = memberId;
         this.nickname = nickname;
         this.memberProfile = memberProfile;
@@ -30,7 +30,7 @@ public class TeamResultMember {
         this.isTeamMember = isTeamMember == ALIVE ? true : false;
     }
 
-    public TeamResultMember(Long memberId, String nickname, MemberProfileResDto memberProfile, int analysis, int previousRank, Status isTeamMember) {
+    public TeamMemberResult(Long memberId, String nickname, MemberProfileResDto memberProfile, int analysis, int previousRank, Status isTeamMember) {
         this.memberId = memberId;
         this.nickname = nickname;
         this.memberProfile = memberProfile;

--- a/aiku/aiku-main/src/main/java/aiku_main/dto/team/TeamRacingResult.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/dto/team/TeamRacingResult.java
@@ -1,4 +1,4 @@
-package aiku_main.application_event.domain;
+package aiku_main.dto.team;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -9,7 +9,7 @@ import java.util.List;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
-public class TeamBettingResult {
+public class TeamRacingResult {
     private Long groupId;
     private List<TeamResultMember> members;
 }

--- a/aiku/aiku-main/src/main/java/aiku_main/dto/team/TeamRacingResult.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/dto/team/TeamRacingResult.java
@@ -10,6 +10,7 @@ import java.util.List;
 @AllArgsConstructor
 @NoArgsConstructor
 public class TeamRacingResult {
+
     private Long groupId;
-    private List<TeamResultMember> members;
+    private List<TeamMemberResult> members;
 }

--- a/aiku/aiku-main/src/main/java/aiku_main/dto/team/TeamResDto.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/dto/team/TeamResDto.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 import java.time.LocalDateTime;
 
 @Getter
-public class TeamEachListResDto {
+public class TeamResDto {
 
     private Long groupId;
     private String groupName;
@@ -14,7 +14,7 @@ public class TeamEachListResDto {
     private LocalDateTime lastScheduleTime;
 
     @QueryProjection
-    public TeamEachListResDto(Long groupId, String groupName, int memberSize, LocalDateTime lastScheduleTime) {
+    public TeamResDto(Long groupId, String groupName, int memberSize, LocalDateTime lastScheduleTime) {
         this.groupId = groupId;
         this.groupName = groupName;
         this.memberSize = memberSize;

--- a/aiku/aiku-main/src/main/java/aiku_main/dto/team/TeamResultMember.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/dto/team/TeamResultMember.java
@@ -1,9 +1,8 @@
-package aiku_main.application_event.domain;
+package aiku_main.dto.team;
 
 import aiku_main.dto.MemberProfileResDto;
 import com.querydsl.core.annotations.QueryProjection;
 import common.domain.Status;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;

--- a/aiku/aiku-main/src/main/java/aiku_main/dto/team/TeamScheduleListEachResDto.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/dto/team/TeamScheduleListEachResDto.java
@@ -1,5 +1,6 @@
-package aiku_main.dto;
+package aiku_main.dto.team;
 
+import aiku_main.dto.LocationDto;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.querydsl.core.annotations.QueryProjection;
 import common.domain.ExecStatus;

--- a/aiku/aiku-main/src/main/java/aiku_main/dto/team/TeamScheduleListResDto.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/dto/team/TeamScheduleListResDto.java
@@ -1,4 +1,4 @@
-package aiku_main.dto;
+package aiku_main.dto.team;
 
 import common.domain.team.Team;
 import lombok.Getter;

--- a/aiku/aiku-main/src/main/java/aiku_main/repository/MemberRepository.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/repository/MemberRepository.java
@@ -1,5 +1,6 @@
 package aiku_main.repository;
 
+import common.domain.Status;
 import common.domain.member.Member;
 import jakarta.persistence.LockModeType;
 import jakarta.persistence.QueryHint;
@@ -12,6 +13,7 @@ import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
+    Optional<Member> findByIdAndStatus(Long memberId, Status status);
     Optional<Member> findByNickname(String recommenderNickname);
 
     Optional<Member> findByKakaoId(Long aLong);

--- a/aiku/aiku-main/src/main/java/aiku_main/repository/ScheduleQueryRepositoryCustom.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/repository/ScheduleQueryRepositoryCustom.java
@@ -2,6 +2,7 @@ package aiku_main.repository;
 
 import aiku_main.application_event.domain.ScheduleArrivalMember;
 import aiku_main.dto.*;
+import aiku_main.dto.team.TeamScheduleListEachResDto;
 import common.domain.ExecStatus;
 import common.domain.schedule.Schedule;
 import common.domain.schedule.ScheduleMember;

--- a/aiku/aiku-main/src/main/java/aiku_main/repository/ScheduleQueryRepositoryCustomImpl.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/repository/ScheduleQueryRepositoryCustomImpl.java
@@ -2,6 +2,7 @@ package aiku_main.repository;
 
 import aiku_main.application_event.domain.ScheduleArrivalMember;
 import aiku_main.dto.*;
+import aiku_main.dto.team.TeamScheduleListEachResDto;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;

--- a/aiku/aiku-main/src/main/java/aiku_main/repository/TeamQueryRepository.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/repository/TeamQueryRepository.java
@@ -2,6 +2,7 @@ package aiku_main.repository;
 
 import common.domain.Status;
 import common.domain.team.Team;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;

--- a/aiku/aiku-main/src/main/java/aiku_main/repository/TeamQueryRepositoryCustom.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/repository/TeamQueryRepositoryCustom.java
@@ -5,21 +5,18 @@ import aiku_main.dto.team.TeamResDto;
 import aiku_main.dto.team.TeamMemberResult;
 import common.domain.team.Team;
 import common.domain.team.TeamMember;
-import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface TeamQueryRepositoryCustom {
 
-    Optional<Team> findTeamWithMember(Long teamId);
     Optional<Team> findTeamWithResult(Long teamId);
-
     List<TeamMember> findTeamMembersWithMemberInTeam(Long teamId);
     Optional<TeamMember> findTeamMember(Long teamId, Long memberId);
     Optional<TeamMember> findDeletedTeamMember(Long teamId, Long memberId);
 
-    boolean existTeamMember(@Param("memberId") Long memberId, @Param("teamId") Long teamId);
+    boolean existTeamMember(Long memberId, Long teamId);
     Long countOfTeamMember(Long teamId);
 
     List<TeamMemberResDto> getTeamMemberList(Long teamId);

--- a/aiku/aiku-main/src/main/java/aiku_main/repository/TeamQueryRepositoryCustom.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/repository/TeamQueryRepositoryCustom.java
@@ -1,7 +1,8 @@
 package aiku_main.repository;
 
-import aiku_main.dto.team.TeamResultMember;
-import aiku_main.dto.team.TeamEachListResDto;
+import aiku_main.dto.team.TeamMemberResDto;
+import aiku_main.dto.team.TeamResDto;
+import aiku_main.dto.team.TeamMemberResult;
 import common.domain.team.Team;
 import common.domain.team.TeamMember;
 import org.springframework.data.repository.query.Param;
@@ -12,14 +13,16 @@ import java.util.Optional;
 public interface TeamQueryRepositoryCustom {
 
     Optional<Team> findTeamWithMember(Long teamId);
+    Optional<Team> findTeamWithResult(Long teamId);
 
     List<TeamMember> findTeamMembersWithMemberInTeam(Long teamId);
     Optional<TeamMember> findAliveTeamMember(Long teamId, Long memberId);
     Optional<TeamMember> findTeamMember(Long teamId, Long memberId);
 
     boolean existTeamMember(@Param("memberId") Long memberId, @Param("teamId") Long teamId);
-    Long countOfAliveTeamMember(Long teamId);
+    Long countOfTeamMember(Long teamId);
 
-    List<TeamEachListResDto> getTeamList(Long memberId, int page);
-    List<TeamResultMember> getTeamLateTimeResult(Long teamId);
+    List<TeamMemberResDto> getTeamMemberList(Long teamId);
+    List<TeamResDto> getTeamList(Long memberId, int page);
+    List<TeamMemberResult> getTeamLateTimeResult(Long teamId);
 }

--- a/aiku/aiku-main/src/main/java/aiku_main/repository/TeamQueryRepositoryCustom.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/repository/TeamQueryRepositoryCustom.java
@@ -1,7 +1,7 @@
 package aiku_main.repository;
 
-import aiku_main.application_event.domain.TeamResultMember;
-import aiku_main.dto.TeamEachListResDto;
+import aiku_main.dto.team.TeamResultMember;
+import aiku_main.dto.team.TeamEachListResDto;
 import common.domain.team.Team;
 import common.domain.team.TeamMember;
 import org.springframework.data.repository.query.Param;

--- a/aiku/aiku-main/src/main/java/aiku_main/repository/TeamQueryRepositoryCustom.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/repository/TeamQueryRepositoryCustom.java
@@ -16,8 +16,8 @@ public interface TeamQueryRepositoryCustom {
     Optional<Team> findTeamWithResult(Long teamId);
 
     List<TeamMember> findTeamMembersWithMemberInTeam(Long teamId);
-    Optional<TeamMember> findAliveTeamMember(Long teamId, Long memberId);
     Optional<TeamMember> findTeamMember(Long teamId, Long memberId);
+    Optional<TeamMember> findDeletedTeamMember(Long teamId, Long memberId);
 
     boolean existTeamMember(@Param("memberId") Long memberId, @Param("teamId") Long teamId);
     Long countOfTeamMember(Long teamId);

--- a/aiku/aiku-main/src/main/java/aiku_main/repository/TeamQueryRepositoryCustomImpl.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/repository/TeamQueryRepositoryCustomImpl.java
@@ -31,16 +31,6 @@ public class TeamQueryRepositoryCustomImpl implements TeamQueryRepositoryCustom 
     private final JPAQueryFactory query;
 
     @Override
-    public Optional<Team> findTeamWithMember(Long teamId) {
-        return query.selectFrom(team)
-                .leftJoin(team.teamMembers, teamMember).fetchJoin()
-                .where(team.id.eq(teamId),
-                        team.status.eq(ALIVE),
-                        teamMember.status.eq(ALIVE))
-                .stream().findFirst();
-    }
-
-    @Override
     public Optional<Team> findTeamWithResult(Long teamId) {
         Team findTeam = query.selectFrom(team)
                 .leftJoin(team.teamResult, teamResult).fetchJoin()

--- a/aiku/aiku-main/src/main/java/aiku_main/repository/TeamQueryRepositoryCustomImpl.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/repository/TeamQueryRepositoryCustomImpl.java
@@ -17,6 +17,7 @@ import java.util.Optional;
 
 import static common.domain.ExecStatus.TERM;
 import static common.domain.Status.ALIVE;
+import static common.domain.Status.DELETE;
 import static common.domain.member.QMember.member;
 import static common.domain.schedule.QSchedule.schedule;
 import static common.domain.schedule.QScheduleMember.scheduleMember;
@@ -97,7 +98,7 @@ public class TeamQueryRepositoryCustomImpl implements TeamQueryRepositoryCustom 
     }
 
     @Override
-    public Optional<TeamMember> findAliveTeamMember(Long teamId, Long memberId) {
+    public Optional<TeamMember> findTeamMember(Long teamId, Long memberId) {
         TeamMember result = query.selectFrom(teamMember)
                 .where(teamMember.team.id.eq(teamId),
                         teamMember.member.id.eq(memberId),
@@ -108,10 +109,11 @@ public class TeamQueryRepositoryCustomImpl implements TeamQueryRepositoryCustom 
     }
 
     @Override
-    public Optional<TeamMember> findTeamMember(Long teamId, Long memberId) {
+    public Optional<TeamMember> findDeletedTeamMember(Long teamId, Long memberId) {
         TeamMember result = query.selectFrom(teamMember)
                 .where(teamMember.team.id.eq(teamId),
-                        teamMember.member.id.eq(memberId))
+                        teamMember.member.id.eq(memberId),
+                        teamMember.status.eq(DELETE))
                 .fetchOne();
 
         return Optional.ofNullable(result);

--- a/aiku/aiku-main/src/main/java/aiku_main/repository/TeamQueryRepositoryCustomImpl.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/repository/TeamQueryRepositoryCustomImpl.java
@@ -1,8 +1,8 @@
 package aiku_main.repository;
 
-import aiku_main.application_event.domain.TeamResultMember;
+import aiku_main.dto.team.TeamResultMember;
 import aiku_main.dto.MemberProfileResDto;
-import aiku_main.dto.TeamEachListResDto;
+import aiku_main.dto.team.TeamEachListResDto;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;

--- a/aiku/aiku-main/src/main/java/aiku_main/service/ScheduleService.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/service/ScheduleService.java
@@ -5,6 +5,8 @@ import aiku_main.application_event.domain.ScheduleArrivalResult;
 import aiku_main.application_event.publisher.PointChangeEventPublisher;
 import aiku_main.application_event.publisher.ScheduleEventPublisher;
 import aiku_main.dto.*;
+import aiku_main.dto.team.TeamScheduleListEachResDto;
+import aiku_main.dto.team.TeamScheduleListResDto;
 import aiku_main.exception.ScheduleException;
 import aiku_main.exception.TeamException;
 import aiku_main.kafka.KafkaProducerService;

--- a/aiku/aiku-main/src/main/java/aiku_main/service/TeamService.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/service/TeamService.java
@@ -9,6 +9,7 @@ import aiku_main.dto.*;
 import aiku_main.dto.team.TeamAddDto;
 import aiku_main.dto.team.TeamDetailResDto;
 import aiku_main.dto.team.TeamEachListResDto;
+import aiku_main.exception.MemberNotFoundException;
 import aiku_main.exception.TeamException;
 import aiku_main.repository.*;
 import aiku_main.repository.dto.TeamBettingResultMemberDto;
@@ -296,17 +297,14 @@ public class TeamService {
         }
     }
 
-    //==* 기타 메서드 *==
     private Member findMember(Long memberId){
-        return memberRepository.findById(memberId).orElseThrow();
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberNotFoundException());
     }
 
     private Team findTeamById(Long teamId){
-        Team team = teamQueryRepository.findByIdAndStatus(teamId, ALIVE).orElse(null);
-        if (team == null) {
-            throw new TeamException(NO_SUCH_TEAM);
-        }
-        return team;
+        return teamQueryRepository.findByIdAndStatus(teamId, ALIVE)
+                .orElseThrow(() -> new TeamException(NO_SUCH_TEAM));
     }
 
     private void checkExistTeam(Long teamId){

--- a/aiku/aiku-main/src/main/java/aiku_main/service/TeamService.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/service/TeamService.java
@@ -120,7 +120,7 @@ public class TeamService {
     @Transactional
     public void analyzeLateTimeResult(Long scheduleId) {
         Schedule schedule = scheduleQueryRepository.findById(scheduleId).orElseThrow();
-        Team team = teamQueryRepository.findById(schedule.getTeam().getId()).orElseThrow();
+        Team team = findTeamWithResult(schedule.getTeam().getId());
 
         List<TeamMemberResult> lateTeamMemberRanking = teamQueryRepository.getTeamLateTimeResult(team.getId());
 
@@ -158,7 +158,7 @@ public class TeamService {
     @Transactional
     public void analyzeBettingResult(Long scheduleId) {
         Schedule schedule = scheduleQueryRepository.findById(scheduleId).orElseThrow();
-        Team team = teamQueryRepository.findById(schedule.getTeam().getId()).orElseThrow();
+        Team team = findTeamWithResult(schedule.getTeam().getId());
 
         Map<Long, List<TeamBettingResultMemberDto>> memberBettingsMap = bettingQueryRepository.findMemberTermBettingsInTeam(team.getId());
 
@@ -206,7 +206,7 @@ public class TeamService {
     @Transactional
     public void analyzeRacingResult(Long scheduleId) {
         Schedule schedule = scheduleQueryRepository.findById(scheduleId).orElseThrow();
-        Team team = teamQueryRepository.findById(schedule.getTeam().getId()).orElseThrow();
+        Team team = findTeamWithResult(schedule.getTeam().getId());
 
         Map<Long, List<TeamRacingResultMemberDto>> memberRacingsMap = racingQueryRepository.findMemberWithTermRacingsInTeam(team.getId());
 
@@ -253,7 +253,7 @@ public class TeamService {
 
     @Transactional
     public void updateLateTimeResultOfExitMember(Long memberId, Long teamId) {
-        Team team = teamQueryRepository.findById(teamId).orElseThrow();
+        Team team = findTeamWithResult(teamId);
         if (team.getTeamResult() == null || team.getTeamResult().getLateTimeResult() == null) {
             return;
         }

--- a/aiku/aiku-main/src/main/java/aiku_main/service/TeamService.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/service/TeamService.java
@@ -8,7 +8,7 @@ import aiku_main.exception.TeamException;
 import aiku_main.repository.*;
 import aiku_main.repository.dto.TeamBettingResultMemberDto;
 import aiku_main.repository.dto.TeamRacingResultMemberDto;
-import aiku_main.util.ObjectMapperUtil;
+import common.util.ObjectMapperUtil;
 import common.domain.member.Member;
 import common.domain.schedule.Schedule;
 import common.domain.team.Team;

--- a/aiku/aiku-main/src/main/java/aiku_main/service/TeamService.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/service/TeamService.java
@@ -288,7 +288,7 @@ public class TeamService {
     }
 
     private TeamMember findTeamMember(Long memberId, Long teamId){
-        return teamQueryRepository.findAliveTeamMember(teamId, memberId)
+        return teamQueryRepository.findTeamMember(teamId, memberId)
                 .orElseThrow(() -> new TeamException(INTERNAL_SERVER_ERROR));
     }
 

--- a/aiku/aiku-main/src/main/java/aiku_main/service/TeamService.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/service/TeamService.java
@@ -15,6 +15,7 @@ import common.domain.member.Member;
 import common.domain.schedule.Schedule;
 import common.domain.team.Team;
 import common.domain.team.TeamMember;
+import common.domain.team.TeamResult;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -252,14 +253,25 @@ public class TeamService {
     }
 
     @Transactional
-    public void updateLateTimeResultOfExitMember(Long memberId, Long teamId) {
+    public void updateTeamResultOfExitMember(Long memberId, Long teamId) {
         Team team = findTeamWithResult(teamId);
-        if (team.getTeamResult() == null || team.getTeamResult().getLateTimeResult() == null) {
+        if (team.getTeamResult() == null) {
+            return;
+        }
+
+        updateLateTimeResultOfExitMember(memberId, team);
+        updateBettingTimeResultOfExitMember(memberId, team);
+        updateRacingTimeResultOfExitMember(memberId, team);
+    }
+
+    private void updateLateTimeResultOfExitMember(Long memberId, Team team){
+        TeamResult teamResult = team.getTeamResult();
+        if (teamResult.getLateTimeResult() == null) {
             return;
         }
 
         try {
-            TeamLateTimeResult result = objectMapper.readValue(team.getTeamResult().getLateTimeResult(), TeamLateTimeResult.class);
+            TeamLateTimeResult result = objectMapper.readValue(teamResult.getLateTimeResult(), TeamLateTimeResult.class);
             result.getMembers().forEach(resultMember -> {
                 if (resultMember.getMemberId().equals(memberId)) {
                     resultMember.setTeamMember(false);
@@ -267,6 +279,46 @@ public class TeamService {
             });
 
             team.setTeamLateResult(objectMapper.writeValueAsString(result));
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void updateBettingTimeResultOfExitMember(Long memberId, Team team){
+        TeamResult teamResult = team.getTeamResult();
+        if (teamResult.getTeamBettingResult() == null) {
+            return;
+        }
+
+        try {
+            TeamBettingResult result = objectMapper.readValue(teamResult.getTeamBettingResult(), TeamBettingResult.class);
+            result.getMembers().forEach(resultMember -> {
+                if (resultMember.getMemberId().equals(memberId)) {
+                    resultMember.setTeamMember(false);
+                }
+            });
+
+            team.setTeamBettingResult(objectMapper.writeValueAsString(result));
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void updateRacingTimeResultOfExitMember(Long memberId, Team team){
+        TeamResult teamResult = team.getTeamResult();
+        if (teamResult.getTeamRacingResult() == null) {
+            return;
+        }
+
+        try {
+            TeamRacingResult result = objectMapper.readValue(teamResult.getTeamRacingResult(), TeamRacingResult.class);
+            result.getMembers().forEach(resultMember -> {
+                if (resultMember.getMemberId().equals(memberId)) {
+                    resultMember.setTeamMember(false);
+                }
+            });
+
+            team.setTeamRacingResult(objectMapper.writeValueAsString(result));
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
         }

--- a/aiku/aiku-main/src/main/java/aiku_main/service/TeamService.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/service/TeamService.java
@@ -1,11 +1,14 @@
 package aiku_main.service;
 
-import aiku_main.application_event.domain.TeamBettingResult;
-import aiku_main.application_event.domain.TeamLateTimeResult;
-import aiku_main.application_event.domain.TeamRacingResult;
-import aiku_main.application_event.domain.TeamResultMember;
+import aiku_main.dto.team.TeamBettingResult;
+import aiku_main.dto.team.TeamLateTimeResult;
+import aiku_main.dto.team.TeamRacingResult;
+import aiku_main.dto.team.TeamResultMember;
 import aiku_main.application_event.publisher.TeamEventPublisher;
 import aiku_main.dto.*;
+import aiku_main.dto.team.TeamAddDto;
+import aiku_main.dto.team.TeamDetailResDto;
+import aiku_main.dto.team.TeamEachListResDto;
 import aiku_main.exception.TeamException;
 import aiku_main.repository.*;
 import aiku_main.repository.dto.TeamBettingResultMemberDto;

--- a/aiku/aiku-main/src/main/java/aiku_main/service/TeamService.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/service/TeamService.java
@@ -292,12 +292,6 @@ public class TeamService {
                 .orElseThrow(() -> new TeamException(INTERNAL_SERVER_ERROR));
     }
 
-    private void checkExistTeam(Long teamId){
-        if(!teamQueryRepository.existsById(teamId)){
-            throw new TeamException(NO_SUCH_TEAM);
-        }
-    }
-
     private void checkTeamMember(Long memberId, Long teamId, boolean isMember){
         if(teamQueryRepository.existTeamMember(memberId, teamId) != isMember){
             if(isMember){

--- a/aiku/aiku-main/src/main/java/aiku_main/util/ObjectMapperUtil.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/util/ObjectMapperUtil.java
@@ -1,0 +1,29 @@
+package aiku_main.util;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class ObjectMapperUtil {
+
+    private final ObjectMapper objectMapper;
+
+    public <T> T parseJson(String json, Class<T> valueType) {
+        try {
+            return objectMapper.readValue(json, valueType);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("ObjectMapper를 통한 역직렬화가 불가능합니다.", e);
+        }
+    }
+
+    public String toJson(Object value) {
+        try {
+            return objectMapper.writeValueAsString(value);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("ObjectMapper를 통한 직렬화가 불가능합니다.", e);
+        }
+    }
+}

--- a/aiku/aiku-main/src/test/java/aiku_main/controller/TeamControllerTest.java
+++ b/aiku/aiku-main/src/test/java/aiku_main/controller/TeamControllerTest.java
@@ -1,6 +1,6 @@
 package aiku_main.controller;
 
-import aiku_main.dto.TeamAddDto;
+import aiku_main.dto.team.TeamAddDto;
 import aiku_main.service.TeamService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;

--- a/aiku/aiku-main/src/test/java/aiku_main/integration_test/ScheduleServiceIntegrationTest.java
+++ b/aiku/aiku-main/src/test/java/aiku_main/integration_test/ScheduleServiceIntegrationTest.java
@@ -3,6 +3,8 @@ package aiku_main.integration_test;
 import aiku_main.application_event.domain.ScheduleArrivalMember;
 import aiku_main.application_event.domain.ScheduleArrivalResult;
 import aiku_main.dto.*;
+import aiku_main.dto.team.TeamScheduleListEachResDto;
+import aiku_main.dto.team.TeamScheduleListResDto;
 import aiku_main.exception.ScheduleException;
 import aiku_main.exception.TeamException;
 import aiku_main.repository.MemberRepository;

--- a/aiku/aiku-main/src/test/java/aiku_main/integration_test/TeamServiceIntegrationTest.java
+++ b/aiku/aiku-main/src/test/java/aiku_main/integration_test/TeamServiceIntegrationTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
@@ -218,6 +219,7 @@ public class TeamServiceIntegrationTest {
                 .isInstanceOf(TeamException.class);
     }
 
+    @Rollback(value = false)
     @Test
     void 그룹_목록_조회() {
         //given
@@ -233,20 +235,20 @@ public class TeamServiceIntegrationTest {
         teamC.addTeamMember(member3);
         em.persist(teamC);
 
-        Schedule scheduleA1 = createSchedule(member1, teamA, LocalDateTime.now().minusDays(1));
-        scheduleA1.setTerm(LocalDateTime.now());
+        Schedule scheduleA1 = createSchedule(member1, teamA, LocalDateTime.now().minusDays(3));
+        scheduleA1.setTerm(LocalDateTime.now().minusDays(3));
         em.persist(scheduleA1);
 
-        Schedule scheduleB1 = createSchedule(member1, teamA, LocalDateTime.now().minusDays(2));
-        scheduleB1.setTerm(LocalDateTime.now());
+        Schedule scheduleB1 = createSchedule(member1, teamB, LocalDateTime.now().plusDays(1));
         em.persist(scheduleB1);
 
-        Schedule scheduleB2 = createSchedule(member1, teamA, LocalDateTime.now().plusDays(1));
-        em.persist(scheduleB2);
-
-        Schedule scheduleC1 = createSchedule(member1, teamA, LocalDateTime.now());
-        scheduleC1.setTerm(LocalDateTime.now());
+        Schedule scheduleC1 = createSchedule(member1, teamC, LocalDateTime.now().minusDays(5));
+        scheduleC1.setTerm(LocalDateTime.now().minusDays(5));
         em.persist(scheduleC1);
+
+        Schedule scheduleC2 = createSchedule(member1, teamC, LocalDateTime.now().minusDays(1));
+        scheduleC2.setTerm(LocalDateTime.now().minusDays(1));
+        em.persist(scheduleC2);
 
         //when
         List<TeamResDto> data = teamService.getTeamList(member1.getId(), 1).getData();

--- a/aiku/aiku-main/src/test/java/aiku_main/integration_test/TeamServiceIntegrationTest.java
+++ b/aiku/aiku-main/src/test/java/aiku_main/integration_test/TeamServiceIntegrationTest.java
@@ -1,10 +1,14 @@
 package aiku_main.integration_test;
 
-import aiku_main.application_event.domain.TeamBettingResult;
-import aiku_main.application_event.domain.TeamLateTimeResult;
-import aiku_main.application_event.domain.TeamRacingResult;
-import aiku_main.application_event.domain.TeamResultMember;
+import aiku_main.dto.team.TeamBettingResult;
+import aiku_main.dto.team.TeamLateTimeResult;
+import aiku_main.dto.team.TeamRacingResult;
+import aiku_main.dto.team.TeamResultMember;
 import aiku_main.dto.*;
+import aiku_main.dto.team.TeamAddDto;
+import aiku_main.dto.team.TeamDetailResDto;
+import aiku_main.dto.team.TeamEachListResDto;
+import aiku_main.dto.team.TeamMemberResDto;
 import aiku_main.exception.TeamException;
 import aiku_main.repository.MemberRepository;
 import aiku_main.repository.TeamQueryRepository;

--- a/aiku/aiku-main/src/test/java/aiku_main/integration_test/TeamServiceIntegrationTest.java
+++ b/aiku/aiku-main/src/test/java/aiku_main/integration_test/TeamServiceIntegrationTest.java
@@ -21,7 +21,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.Rollback;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
@@ -219,7 +218,6 @@ public class TeamServiceIntegrationTest {
                 .isInstanceOf(TeamException.class);
     }
 
-    @Rollback(value = false)
     @Test
     void 그룹_목록_조회() {
         //given

--- a/aiku/aiku-main/src/test/java/aiku_main/integration_test/TeamServiceIntegrationTest.java
+++ b/aiku/aiku-main/src/test/java/aiku_main/integration_test/TeamServiceIntegrationTest.java
@@ -1,7 +1,6 @@
 package aiku_main.integration_test;
 
 import aiku_main.dto.team.*;
-import aiku_main.dto.*;
 import aiku_main.dto.team.TeamResDto;
 import aiku_main.exception.TeamException;
 import aiku_main.repository.MemberRepository;
@@ -29,6 +28,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 @Transactional
 @SpringBootTest
 public class TeamServiceIntegrationTest {
@@ -65,18 +65,18 @@ public class TeamServiceIntegrationTest {
 
     @Test
     void 그룹_등록() {
-        //given
         //when
         TeamAddDto teamDto = new TeamAddDto("group1");
         Long teamId = teamService.addTeam(member1.getId(), teamDto);
 
         //then
-        Team team = teamQueryRepository.findById(teamId).get();
+        Team team = teamQueryRepository.findById(teamId).orElse(null);
+        assertThat(team).isNotNull();
         assertThat(team.getTeamName()).isEqualTo(teamDto.getGroupName());
-        assertThat(team.getTeamMembers().size()).isEqualTo(1);
+        assertThat(team.getTeamMembers()).hasSize(1);
 
         TeamMember teamMember = team.getTeamMembers().get(0);
-        assertThat(teamMember.getMember().getId()).isEqualTo(member1.getId());
+        assertThat(teamMember.getMember().getId()).isEqualTo(member1.getId()); //그룹을 등록한 멤버는 그룹 자동 참가됨
     }
 
     @Test
@@ -89,8 +89,12 @@ public class TeamServiceIntegrationTest {
         Long teamId = teamService.enterTeam(member2.getId(), team.getId());
 
         //then
-        TeamMember teamMember = teamQueryRepository.findAliveTeamMember(teamId, member2.getId()).orElse(null);
-        assertThat(teamMember).isNotNull();
+        Team testTeam = teamQueryRepository.findById(teamId).orElse(null);
+        assertThat(testTeam).isNotNull();
+        assertThat(testTeam.getTeamMembers()).hasSize(2);
+        assertThat(testTeam.getTeamMembers())
+                .extracting(teamMember -> teamMember.getMember().getId())
+                .containsExactlyInAnyOrder(member1.getId(), member2.getId());
     }
 
     @Test
@@ -101,7 +105,8 @@ public class TeamServiceIntegrationTest {
         em.persist(team);
 
         //when
-        assertThatThrownBy(() -> teamService.enterTeam(member2.getId(), team.getId())).isInstanceOf(TeamException.class);
+        assertThatThrownBy(() -> teamService.enterTeam(member2.getId(), team.getId()))
+                .isInstanceOf(TeamException.class);
     }
 
     @Test
@@ -120,9 +125,8 @@ public class TeamServiceIntegrationTest {
         assertThat(findTeam).isNotNull();
         assertThat(findTeam.getStatus()).isEqualTo(Status.ALIVE);
 
-        TeamMember teamMember = teamQueryRepository.findTeamMember(team.getId(), member2.getId()).orElse(null);
+        TeamMember teamMember = teamQueryRepository.findDeletedTeamMember(team.getId(), member2.getId()).orElse(null);
         assertThat(teamMember).isNotNull();
-        assertThat(teamMember.getStatus()).isEqualTo(Status.DELETE);
     }
 
     @Test
@@ -132,7 +136,8 @@ public class TeamServiceIntegrationTest {
         em.persist(team);
 
         //when
-        assertThatThrownBy(() -> teamService.exitTeam(member2.getId(), team.getId())).isInstanceOf(TeamException.class);
+        assertThatThrownBy(() -> teamService.exitTeam(member2.getId(), team.getId()))
+                .isInstanceOf(TeamException.class);
     }
 
     @Test
@@ -141,12 +146,14 @@ public class TeamServiceIntegrationTest {
         Team team = Team.create(member1, "team1");
         em.persist(team);
 
-        Schedule schedule = Schedule.create(member1, new TeamValue(team), "sche1", LocalDateTime.now().plusDays(1), new Location("loc", 1.0, 1.0), 0);
+        Schedule schedule = Schedule.create(member1, new TeamValue(team), "sche1",
+                LocalDateTime.now().plusDays(1), new Location("loc", 1.0, 1.0), 0);
         schedule.setRun();
         em.persist(schedule);
 
         //when
-        assertThatThrownBy(() -> teamService.exitTeam(member1.getId(), team.getId())).isInstanceOf(TeamException.class);
+        assertThatThrownBy(() -> teamService.exitTeam(member1.getId(), team.getId()))
+                .isInstanceOf(TeamException.class);
     }
 
     @Test
@@ -160,7 +167,8 @@ public class TeamServiceIntegrationTest {
         teamService.exitTeam(member2.getId(), team.getId());
 
         //when
-        assertThatThrownBy(() -> teamService.exitTeam(member2.getId(), team.getId())).isInstanceOf(TeamException.class);
+        assertThatThrownBy(() -> teamService.exitTeam(member2.getId(), team.getId()))
+                .isInstanceOf(TeamException.class);
     }
 
     @Test
@@ -173,9 +181,9 @@ public class TeamServiceIntegrationTest {
         teamService.exitTeam(member1.getId(), team.getId());
 
         //then
-        Team findTeam = teamQueryRepository.findById(team.getId()).orElse(null);
-        assertThat(findTeam).isNotNull();
-        assertThat(findTeam.getStatus()).isEqualTo(Status.DELETE);
+        Team testTeam = teamQueryRepository.findById(team.getId()).orElse(null);
+        assertThat(testTeam).isNotNull();
+        assertThat(testTeam.getStatus()).isEqualTo(Status.DELETE);
     }
 
     @Test
@@ -193,8 +201,10 @@ public class TeamServiceIntegrationTest {
         assertThat(result.getGroupName()).isEqualTo(team.getTeamName());
 
         List<TeamMemberResDto> teamMemberDtos = result.getMembers();
-        assertThat(teamMemberDtos.size()).isEqualTo(2);
-        assertThat(teamMemberDtos).extracting("memberId").containsExactly(member1.getId(), member2.getId());
+        assertThat(teamMemberDtos).hasSize(2);
+        assertThat(teamMemberDtos)
+                .extracting(TeamMemberResDto::getMemberId)
+                .containsExactly(member1.getId(), member2.getId());
     }
 
     @Test
@@ -204,7 +214,8 @@ public class TeamServiceIntegrationTest {
         em.persist(team);
 
         //when
-        assertThatThrownBy(() -> teamService.getTeamDetail(member2.getId(), team.getId())).isInstanceOf(TeamException.class);
+        assertThatThrownBy(() -> teamService.getTeamDetail(member2.getId(), team.getId()))
+                .isInstanceOf(TeamException.class);
     }
 
     @Test
@@ -222,41 +233,32 @@ public class TeamServiceIntegrationTest {
         teamC.addTeamMember(member3);
         em.persist(teamC);
 
-        Schedule scheduleA1 = Schedule.create(member1, new TeamValue(teamA), "scheduleA1", LocalDateTime.now().minusDays(1),
-                new Location("loc1", 1.1, 1.1), 0);
+        Schedule scheduleA1 = createSchedule(member1, teamA, LocalDateTime.now().minusDays(1));
         scheduleA1.setTerm(LocalDateTime.now());
         em.persist(scheduleA1);
 
-        Schedule scheduleB1 = Schedule.create(member2, new TeamValue(teamB), "scheduleB1", LocalDateTime.now().minusDays(2),
-                new Location("loc1", 1.1, 1.1), 0);
+        Schedule scheduleB1 = createSchedule(member1, teamA, LocalDateTime.now().minusDays(2));
         scheduleB1.setTerm(LocalDateTime.now());
         em.persist(scheduleB1);
 
-        Schedule scheduleB2 = Schedule.create(member2, new TeamValue(teamB), "scheduleB2", LocalDateTime.now().minusDays(3),
-                new Location("loc1", 1.1, 1.1), 0);
-        scheduleB2.setTerm(LocalDateTime.now());
+        Schedule scheduleB2 = createSchedule(member1, teamA, LocalDateTime.now().plusDays(1));
         em.persist(scheduleB2);
 
-        Schedule scheduleB3 = Schedule.create(member2, new TeamValue(teamB), "scheduleB3", LocalDateTime.now().minusDays(4),
-                new Location("loc1", 1.1, 1.1), 0);
-        scheduleB3.setTerm(LocalDateTime.now());
-        em.persist(scheduleB3);
-
-
-        Schedule scheduleC1 = Schedule.create(member2, new TeamValue(teamC), "scheduleC1", LocalDateTime.now(),
-                new Location("loc1", 1.1, 1.1), 0);
+        Schedule scheduleC1 = createSchedule(member1, teamA, LocalDateTime.now());
         scheduleC1.setTerm(LocalDateTime.now());
         em.persist(scheduleC1);
 
         //when
-        int page = 1;
-        DataResDto<List<TeamResDto>> result = teamService.getTeamList(member1.getId(), page);
+        List<TeamResDto> data = teamService.getTeamList(member1.getId(), 1).getData();
 
         //then
-        List<TeamResDto> data = result.getData();
-        assertThat(data.size()).isEqualTo(3);
-        assertThat(data).extracting("groupId").containsExactly(teamC.getId(), teamA.getId(), teamB.getId());
-        assertThat(data).extracting("memberSize").containsExactly(3, 1, 2);
+        assertThat(data).hasSize(3);
+        assertThat(data)
+                .extracting(TeamResDto::getGroupId)
+                .containsExactly(teamC.getId(), teamA.getId(), teamB.getId());
+        assertThat(data)
+                .extracting(TeamResDto::getMemberSize)
+                .containsExactly(3, 1, 2);
     }
 
     @Test
@@ -267,39 +269,45 @@ public class TeamServiceIntegrationTest {
         team.addTeamMember(member3);
         em.persist(team);
 
-        Schedule schedule1 = Schedule.create(member1, new TeamValue(team), "schedule1",
-                LocalDateTime.now().minusDays(1), new Location("loc", 1.0, 1.0), 0);
+        LocalDateTime scheduleTime = LocalDateTime.now().minusDays(1);
+
+        Schedule schedule1 = createSchedule(member1, team, scheduleTime);
         schedule1.addScheduleMember(member2, false, 0);
         schedule1.addScheduleMember(member3, false, 0);
         em.persist(schedule1);
 
-        schedule1.arriveScheduleMember(schedule1.getScheduleMembers().get(0), LocalDateTime.now().minusDays(1).plusMinutes(10));
-        schedule1.arriveScheduleMember(schedule1.getScheduleMembers().get(1), LocalDateTime.now().minusDays(1).minusMinutes(10));
-        schedule1.arriveScheduleMember(schedule1.getScheduleMembers().get(2), LocalDateTime.now().minusDays(1).plusMinutes(15));
+        // member1: 10, member2: 0, member3: 15분 지각
+        schedule1.arriveScheduleMember(schedule1.getScheduleMembers().get(0), scheduleTime.plusMinutes(10));
+        schedule1.arriveScheduleMember(schedule1.getScheduleMembers().get(1), scheduleTime.minusMinutes(10));
+        schedule1.arriveScheduleMember(schedule1.getScheduleMembers().get(2), scheduleTime.plusMinutes(15));
         schedule1.setTerm(schedule1.getScheduleTime().plusMinutes(30));
 
-        Schedule schedule2 = Schedule.create(member1, new TeamValue(team), "schedule2",
-                LocalDateTime.now().minusDays(1), new Location("loc", 1.0, 1.0), 0);
+        Schedule schedule2 = createSchedule(member1, team, scheduleTime);
         schedule2.addScheduleMember(member2, false, 0);
         schedule2.addScheduleMember(member3, false, 0);
         em.persist(schedule2);
 
-        schedule2.arriveScheduleMember(schedule2.getScheduleMembers().get(0), LocalDateTime.now().minusDays(1).plusMinutes(20));
-        schedule2.arriveScheduleMember(schedule2.getScheduleMembers().get(1), LocalDateTime.now().minusDays(1).minusMinutes(10));
-        schedule2.arriveScheduleMember(schedule2.getScheduleMembers().get(2), LocalDateTime.now().minusDays(1).minusMinutes(30));
+        // member1: 20, member2: 0, member3: 0분 지각
+        schedule2.arriveScheduleMember(schedule2.getScheduleMembers().get(0), scheduleTime.plusMinutes(20));
+        schedule2.arriveScheduleMember(schedule2.getScheduleMembers().get(1), scheduleTime.minusMinutes(10));
+        schedule2.arriveScheduleMember(schedule2.getScheduleMembers().get(2), scheduleTime.minusMinutes(30));
         schedule2.setTerm(schedule2.getScheduleTime().plusMinutes(30));
 
         //when
         teamService.analyzeLateTimeResult(schedule1.getId());
 
         //then
-        Team findTeam = teamQueryRepository.findById(team.getId()).orElse(null);
-        assertThat(findTeam).isNotNull();
+        Team testTeam = teamQueryRepository.findById(team.getId()).orElse(null);
+        assertThat(testTeam).isNotNull();
 
-        TeamLateTimeResult result = objectMapper.readValue(findTeam.getTeamResult().getLateTimeResult(), TeamLateTimeResult.class);
-        List<TeamMemberResult> lateMemberRanking = result.getMembers();
-        assertThat(lateMemberRanking).extracting("memberId").containsExactly(member1.getId(), member3.getId());
-        assertThat(lateMemberRanking).extracting("analysis").containsExactly(-30, -15);
+        //누적 member1: 30, member2: 0, member3: 15분 지각
+        List<TeamMemberResult> lateMemberRanking = objectMapper.readValue(testTeam.getTeamResult().getLateTimeResult(), TeamLateTimeResult.class).getMembers();
+        assertThat(lateMemberRanking)
+                .extracting(TeamMemberResult::getMemberId)
+                .containsExactly(member1.getId(), member3.getId());
+        assertThat(lateMemberRanking)
+                .extracting(TeamMemberResult::getAnalysis)
+                .containsExactly(-30, -15);
     }
 
     @Test
@@ -310,41 +318,47 @@ public class TeamServiceIntegrationTest {
         team.addTeamMember(member3);
         em.persist(team);
 
-        Schedule schedule1 = Schedule.create(member1, new TeamValue(team), "schedule1",
-                LocalDateTime.now().minusDays(1), new Location("loc", 1.0, 1.0), 0);
+        LocalDateTime scheduleTime = LocalDateTime.now().minusDays(1);
+
+        Schedule schedule1 = createSchedule(member1, team, scheduleTime);
         schedule1.addScheduleMember(member2, false, 0);
         schedule1.addScheduleMember(member3, false, 0);
         em.persist(schedule1);
 
-        schedule1.arriveScheduleMember(schedule1.getScheduleMembers().get(0), LocalDateTime.now().minusDays(1).plusMinutes(20));
-        schedule1.arriveScheduleMember(schedule1.getScheduleMembers().get(1), LocalDateTime.now().minusDays(1).plusMinutes(10));
-        schedule1.arriveScheduleMember(schedule1.getScheduleMembers().get(2), LocalDateTime.now().minusDays(1).plusMinutes(5));
+        //member1: 20, member2: 10, member3: 5분 지각
+        schedule1.arriveScheduleMember(schedule1.getScheduleMembers().get(0), scheduleTime.plusMinutes(20));
+        schedule1.arriveScheduleMember(schedule1.getScheduleMembers().get(1), scheduleTime.plusMinutes(10));
+        schedule1.arriveScheduleMember(schedule1.getScheduleMembers().get(2), scheduleTime.plusMinutes(5));
         schedule1.setTerm(schedule1.getScheduleTime().plusMinutes(30));
 
         teamService.analyzeLateTimeResult(schedule1.getId());
 
-        Schedule schedule2 = Schedule.create(member1, new TeamValue(team), "schedule2",
-                LocalDateTime.now().minusDays(1), new Location("loc", 1.0, 1.0), 0);
+        Schedule schedule2 = createSchedule(member1, team, LocalDateTime.now().minusDays(1));
         schedule2.addScheduleMember(member2, false, 0);
         schedule2.addScheduleMember(member3, false, 0);
         em.persist(schedule2);
 
-        schedule2.arriveScheduleMember(schedule2.getScheduleMembers().get(0), LocalDateTime.now().minusDays(1).plusMinutes(10));
-        schedule2.arriveScheduleMember(schedule2.getScheduleMembers().get(1), LocalDateTime.now().minusDays(1).plusMinutes(50));
-        schedule2.arriveScheduleMember(schedule2.getScheduleMembers().get(2), LocalDateTime.now().minusDays(1).plusMinutes(100));
+        //member1: 10, member2: 50, member3: 100분 지각
+        schedule2.arriveScheduleMember(schedule2.getScheduleMembers().get(0), scheduleTime.plusMinutes(10));
+        schedule2.arriveScheduleMember(schedule2.getScheduleMembers().get(1), scheduleTime.plusMinutes(50));
+        schedule2.arriveScheduleMember(schedule2.getScheduleMembers().get(2), scheduleTime.plusMinutes(100));
         schedule2.setTerm(schedule2.getScheduleTime().plusMinutes(30));
 
         //when
+        //member1: 30, member2: 60, member3: 105분 지각
         teamService.analyzeLateTimeResult(schedule1.getId());
 
         //then
-        Team findTeam = teamQueryRepository.findById(team.getId()).orElse(null);
-        assertThat(findTeam).isNotNull();
+        Team testTeam = teamQueryRepository.findById(team.getId()).orElse(null);
+        assertThat(testTeam).isNotNull();
 
-        TeamLateTimeResult result = objectMapper.readValue(findTeam.getTeamResult().getLateTimeResult(), TeamLateTimeResult.class);
-        List<TeamMemberResult> lateMemberRanking = result.getMembers();
-        assertThat(lateMemberRanking).extracting("previousRank").containsExactly(3, 2, 1);
-        assertThat(lateMemberRanking).extracting("rank").containsExactly(1, 2, 3);
+        List<TeamMemberResult> lateMemberRanking = objectMapper.readValue(testTeam.getTeamResult().getLateTimeResult(), TeamLateTimeResult.class).getMembers();
+        assertThat(lateMemberRanking)
+                .extracting(TeamMemberResult::getPreviousRank)
+                .containsExactly(3, 2, 1);
+        assertThat(lateMemberRanking)
+                .extracting(TeamMemberResult::getRank)
+                .containsExactly(1, 2, 3);
     }
 
     @Test
@@ -355,34 +369,37 @@ public class TeamServiceIntegrationTest {
         team.addTeamMember(member3);
         em.persist(team);
 
-        Schedule schedule1 = Schedule.create(member1, new TeamValue(team), "schedule1",
-                LocalDateTime.now().minusDays(1), new Location("loc", 1.0, 1.0), 0);
+        Schedule schedule1 = createSchedule(member1, team, LocalDateTime.now().minusDays(1));
         schedule1.addScheduleMember(member2, false, 0);
         schedule1.addScheduleMember(member3, false, 0);
         em.persist(schedule1);
 
-        Schedule schedule2 = Schedule.create(member1, new TeamValue(team), "schedule2",
-                LocalDateTime.now().minusDays(1), new Location("loc", 1.0, 1.0), 0);
+        Schedule schedule2 = createSchedule(member1, team, LocalDateTime.now().minusDays(1));
         schedule2.addScheduleMember(member2, false, 0);
         schedule2.addScheduleMember(member3, false, 0);
         em.persist(schedule2);
 
+        //member1==member2 >> 100아쿠
         Betting betting1 = Betting.create(new ScheduleMemberValue(schedule1.getScheduleMembers().get(0)), new ScheduleMemberValue(schedule1.getScheduleMembers().get(1)), 100);
         betting1.setDraw();
         em.persist(betting1);
 
+        //member2>member1 >> 100아쿠
         Betting betting2 = Betting.create(new ScheduleMemberValue(schedule1.getScheduleMembers().get(1)), new ScheduleMemberValue(schedule1.getScheduleMembers().get(0)), 100);
         betting2.setWin(100);
         em.persist(betting2);
 
+        //member3>member1 >> 100아쿠
         Betting betting3 = Betting.create(new ScheduleMemberValue(schedule1.getScheduleMembers().get(2)), new ScheduleMemberValue(schedule1.getScheduleMembers().get(0)), 100);
         betting3.setWin(100);
         em.persist(betting3);
 
+        //member2==member3 >> 100아쿠
         Betting betting4 = Betting.create(new ScheduleMemberValue(schedule2.getScheduleMembers().get(1)), new ScheduleMemberValue(schedule2.getScheduleMembers().get(2)), 100);
         betting4.setDraw();
         em.persist(betting4);
 
+        //member3>member1 >> 100아쿠
         Betting betting5 = Betting.create(new ScheduleMemberValue(schedule1.getScheduleMembers().get(2)), new ScheduleMemberValue(schedule1.getScheduleMembers().get(0)), 100);
         betting5.setWin(100);
         em.persist(betting5);
@@ -391,12 +408,15 @@ public class TeamServiceIntegrationTest {
         teamService.analyzeBettingResult(schedule1.getId());
 
         //then
+        //member1:0 member2:100 member3:200
         Team findTeam = teamQueryRepository.findById(team.getId()).orElse(null);
         assertThat(findTeam).isNotNull();
-        List<TeamMemberResult> teamMemberResults = objectMapper.readValue(findTeam.getTeamResult().getTeamBettingResult(), TeamBettingResult.class)
-                .getMembers();
-        assertThat(teamMemberResults.size()).isEqualTo(3);
-        assertThat(teamMemberResults).extracting("memberId").containsExactly(member3.getId(), member2.getId(), member1.getId());
+
+        List<TeamMemberResult> teamMemberResults = objectMapper.readValue(findTeam.getTeamResult().getTeamBettingResult(), TeamBettingResult.class).getMembers();
+        assertThat(teamMemberResults).hasSize(3);
+        assertThat(teamMemberResults)
+                .extracting(TeamMemberResult::getMemberId)
+                .containsExactly(member3.getId(), member2.getId(), member1.getId());
     }
 
     @Test
@@ -407,32 +427,34 @@ public class TeamServiceIntegrationTest {
         team.addTeamMember(member3);
         em.persist(team);
 
-        Schedule schedule1 = Schedule.create(member1, new TeamValue(team), "schedule1",
-                LocalDateTime.now().minusDays(1), new Location("loc", 1.0, 1.0), 0);
+        Schedule schedule1 = createSchedule(member1, team, LocalDateTime.now().minusDays(1));
         schedule1.addScheduleMember(member2, false, 0);
         schedule1.addScheduleMember(member3, false, 0);
         em.persist(schedule1);
 
-        Schedule schedule2 = Schedule.create(member1, new TeamValue(team), "schedule2",
-                LocalDateTime.now().minusDays(1), new Location("loc", 1.0, 1.0), 0);
+        Schedule schedule2 = createSchedule(member1, team, LocalDateTime.now().minusDays(1));
         schedule2.addScheduleMember(member2, false, 0);
         schedule2.addScheduleMember(member3, false, 0);
         em.persist(schedule2);
 
+        //member1>member2 >> 100아쿠
         Betting betting1 = Betting.create(new ScheduleMemberValue(schedule1.getScheduleMembers().get(0)), new ScheduleMemberValue(schedule1.getScheduleMembers().get(1)), 100);
         betting1.setWin(100);
         em.persist(betting1);
 
+        //member2<member3 >> 100아쿠
         Betting betting2 = Betting.create(new ScheduleMemberValue(schedule1.getScheduleMembers().get(1)), new ScheduleMemberValue(schedule1.getScheduleMembers().get(2)), 100);
         betting2.setLose();
         em.persist(betting2);
 
         teamService.analyzeBettingResult(schedule1.getId());
 
+        //member1>member2 >> 100아쿠
         Betting betting4 = Betting.create(new ScheduleMemberValue(schedule2.getScheduleMembers().get(0)), new ScheduleMemberValue(schedule2.getScheduleMembers().get(1)), 100);
         betting4.setWin(100);
         em.persist(betting4);
 
+        //member3>member2 >> 100아쿠
         Betting betting5 = Betting.create(new ScheduleMemberValue(schedule2.getScheduleMembers().get(2)), new ScheduleMemberValue(schedule2.getScheduleMembers().get(1)), 100);
         betting5.setWin(100);
         em.persist(betting5);
@@ -441,12 +463,16 @@ public class TeamServiceIntegrationTest {
         teamService.analyzeBettingResult(schedule1.getId());
 
         //then
-        Team findTeam = teamQueryRepository.findById(team.getId()).orElse(null);
-        assertThat(findTeam).isNotNull();
-        List<TeamMemberResult> teamMemberResults = objectMapper.readValue(findTeam.getTeamResult().getTeamBettingResult(), TeamBettingResult.class)
-                .getMembers();
-        assertThat(teamMemberResults).extracting("rank").containsExactly(1, 2, 3);
-        assertThat(teamMemberResults).extracting("previousRank").containsExactly(1, -1, 2);
+        Team testTeam = teamQueryRepository.findById(team.getId()).orElse(null);
+        assertThat(testTeam).isNotNull();
+
+        List<TeamMemberResult> teamMemberResults = objectMapper.readValue(testTeam.getTeamResult().getTeamBettingResult(), TeamBettingResult.class).getMembers();
+        assertThat(teamMemberResults)
+                .extracting(TeamMemberResult::getRank)
+                .containsExactly(1, 2, 3);
+        assertThat(teamMemberResults)
+                .extracting(TeamMemberResult::getPreviousRank)
+                .containsExactly(1, -1, 2);
     }
 
     @Test
@@ -457,34 +483,37 @@ public class TeamServiceIntegrationTest {
         team.addTeamMember(member3);
         em.persist(team);
 
-        Schedule schedule1 = Schedule.create(member1, new TeamValue(team), "schedule1",
-                LocalDateTime.now().minusDays(1), new Location("loc", 1.0, 1.0), 0);
+        Schedule schedule1 = createSchedule(member1, team, LocalDateTime.now().minusDays(1));
         schedule1.addScheduleMember(member2, false, 0);
         schedule1.addScheduleMember(member3, false, 0);
         em.persist(schedule1);
 
-        Schedule schedule2 = Schedule.create(member1, new TeamValue(team), "schedule2",
-                LocalDateTime.now().minusDays(1), new Location("loc", 1.0, 1.0), 0);
+        Schedule schedule2 = createSchedule(member1, team, LocalDateTime.now().minusDays(1));
         schedule2.addScheduleMember(member2, false, 0);
         schedule2.addScheduleMember(member3, false, 0);
         em.persist(schedule2);
 
+        //member1 > member2 >> 20아쿠
         Racing racing1 = Racing.create(schedule1.getScheduleMembers().get(0).getId(), schedule1.getScheduleMembers().get(1).getId(), 20);
         racing1.termRacing(schedule1.getScheduleMembers().get(0).getId());
         em.persist(racing1);
 
+        //member2 > member3 >> 10아쿠
         Racing racing2 = Racing.create(schedule1.getScheduleMembers().get(1).getId(), schedule1.getScheduleMembers().get(2).getId(), 10);
         racing2.termRacing(schedule1.getScheduleMembers().get(1).getId());
         em.persist(racing2);
 
+        //member1 < member2 >> 20아쿠
         Racing racing3 = Racing.create(schedule2.getScheduleMembers().get(0).getId(), schedule2.getScheduleMembers().get(1).getId(), 20);
         racing3.termRacing(schedule2.getScheduleMembers().get(0).getId());
         em.persist(racing3);
 
+        //member2 > member3 >> 10아쿠
         Racing racing4 = Racing.create(schedule2.getScheduleMembers().get(1).getId(), schedule2.getScheduleMembers().get(2).getId(), 10);
         racing4.termRacing(schedule2.getScheduleMembers().get(1).getId());
         em.persist(racing4);
 
+        //member1 > member3 >> 10아쿠
         Racing racing5 = Racing.create(schedule2.getScheduleMembers().get(2).getId(), schedule2.getScheduleMembers().get(0).getId(), 10);
         racing5.termRacing(schedule2.getScheduleMembers().get(0).getId());
         em.persist(racing5);
@@ -493,12 +522,15 @@ public class TeamServiceIntegrationTest {
         teamService.analyzeRacingResult(schedule1.getId());
 
         //then
+        //member1: 30, member2: 20, member3: 0
         Team findTeam = teamQueryRepository.findById(team.getId()).orElse(null);
         assertThat(findTeam).isNotNull();
-        List<TeamMemberResult> teamMemberResults = objectMapper.readValue(findTeam.getTeamResult().getTeamRacingResult(), TeamRacingResult.class)
-                .getMembers();
-        assertThat(teamMemberResults.size()).isEqualTo(3);
-        assertThat(teamMemberResults).extracting("memberId").containsExactly(member1.getId(), member2.getId(), member3.getId());
+
+        List<TeamMemberResult> teamMemberResults = objectMapper.readValue(findTeam.getTeamResult().getTeamRacingResult(), TeamRacingResult.class).getMembers();
+        assertThat(teamMemberResults).hasSize(3);
+        assertThat(teamMemberResults)
+                .extracting(TeamMemberResult::getMemberId)
+                .containsExactly(member1.getId(), member2.getId(), member3.getId());
     }
 
     @Test
@@ -509,14 +541,12 @@ public class TeamServiceIntegrationTest {
         team.addTeamMember(member3);
         em.persist(team);
 
-        Schedule schedule1 = Schedule.create(member1, new TeamValue(team), "schedule1",
-                LocalDateTime.now().minusDays(1), new Location("loc", 1.0, 1.0), 0);
+        Schedule schedule1 = createSchedule(member1, team, LocalDateTime.now().minusDays(1));
         schedule1.addScheduleMember(member2, false, 0);
         schedule1.addScheduleMember(member3, false, 0);
         em.persist(schedule1);
 
-        Schedule schedule2 = Schedule.create(member1, new TeamValue(team), "schedule2",
-                LocalDateTime.now().minusDays(1), new Location("loc", 1.0, 1.0), 0);
+        Schedule schedule2 = createSchedule(member1, team, LocalDateTime.now().minusDays(1));
         schedule2.addScheduleMember(member2, false, 0);
         schedule2.addScheduleMember(member3, false, 0);
         em.persist(schedule2);
@@ -558,9 +588,18 @@ public class TeamServiceIntegrationTest {
         Team findTeam = teamQueryRepository.findById(team.getId()).orElse(null);
         assertThat(findTeam).isNotNull();
         System.out.println(findTeam.getTeamResult().getTeamRacingResult());
-        List<TeamMemberResult> teamMemberResults = objectMapper.readValue(findTeam.getTeamResult().getTeamRacingResult(), TeamRacingResult.class)
-                .getMembers();
-        assertThat(teamMemberResults).extracting("rank").containsExactly(1, 2, 3, 4);
-        assertThat(teamMemberResults).extracting("previousRank").containsExactly(1, 2, 3, -1);
+
+        List<TeamMemberResult> teamMemberResults = objectMapper.readValue(findTeam.getTeamResult().getTeamRacingResult(), TeamRacingResult.class).getMembers();
+        assertThat(teamMemberResults)
+                .extracting(TeamMemberResult::getRank)
+                .containsExactly(1, 2, 3, 4);
+        assertThat(teamMemberResults)
+                .extracting(TeamMemberResult::getPreviousRank)
+                .containsExactly(1, 2, 3, -1);
+    }
+
+    Schedule createSchedule(Member member, Team team, LocalDateTime startTime) {
+        return Schedule.create(member, new TeamValue(team), "schedule", startTime,
+                new Location("loc1", 1.1, 1.1), 0);
     }
 }

--- a/aiku/aiku-main/src/test/java/aiku_main/integration_test/TeamServiceIntegrationTest.java
+++ b/aiku/aiku-main/src/test/java/aiku_main/integration_test/TeamServiceIntegrationTest.java
@@ -89,10 +89,10 @@ public class TeamServiceIntegrationTest {
         Long teamId = teamService.enterTeam(member2.getId(), team.getId());
 
         //then
-        Team testTeam = teamQueryRepository.findById(teamId).orElse(null);
-        assertThat(testTeam).isNotNull();
-        assertThat(testTeam.getTeamMembers()).hasSize(2);
-        assertThat(testTeam.getTeamMembers())
+        Team resultTeam = teamQueryRepository.findById(teamId).orElse(null);
+        assertThat(resultTeam).isNotNull();
+        assertThat(resultTeam.getTeamMembers()).hasSize(2);
+        assertThat(resultTeam.getTeamMembers())
                 .extracting(teamMember -> teamMember.getMember().getId())
                 .containsExactlyInAnyOrder(member1.getId(), member2.getId());
     }
@@ -121,9 +121,9 @@ public class TeamServiceIntegrationTest {
         teamService.exitTeam(member2.getId(), team.getId());
 
         //then
-        Team findTeam = teamQueryRepository.findById(team.getId()).orElse(null);
-        assertThat(findTeam).isNotNull();
-        assertThat(findTeam.getStatus()).isEqualTo(Status.ALIVE);
+        Team resultTeam = teamQueryRepository.findById(team.getId()).orElse(null);
+        assertThat(resultTeam).isNotNull();
+        assertThat(resultTeam.getStatus()).isEqualTo(Status.ALIVE);
 
         TeamMember teamMember = teamQueryRepository.findDeletedTeamMember(team.getId(), member2.getId()).orElse(null);
         assertThat(teamMember).isNotNull();
@@ -181,9 +181,9 @@ public class TeamServiceIntegrationTest {
         teamService.exitTeam(member1.getId(), team.getId());
 
         //then
-        Team testTeam = teamQueryRepository.findById(team.getId()).orElse(null);
-        assertThat(testTeam).isNotNull();
-        assertThat(testTeam.getStatus()).isEqualTo(Status.DELETE);
+        Team resultTeam = teamQueryRepository.findById(team.getId()).orElse(null);
+        assertThat(resultTeam).isNotNull();
+        assertThat(resultTeam.getStatus()).isEqualTo(Status.DELETE);
     }
 
     @Test
@@ -297,11 +297,11 @@ public class TeamServiceIntegrationTest {
         teamService.analyzeLateTimeResult(schedule1.getId());
 
         //then
-        Team testTeam = teamQueryRepository.findById(team.getId()).orElse(null);
-        assertThat(testTeam).isNotNull();
+        Team resultTeam = teamQueryRepository.findById(team.getId()).orElse(null);
+        assertThat(resultTeam).isNotNull();
 
         //누적 member1: 30, member2: 0, member3: 15분 지각
-        List<TeamMemberResult> lateMemberRanking = objectMapper.readValue(testTeam.getTeamResult().getLateTimeResult(), TeamLateTimeResult.class).getMembers();
+        List<TeamMemberResult> lateMemberRanking = objectMapper.readValue(resultTeam.getTeamResult().getLateTimeResult(), TeamLateTimeResult.class).getMembers();
         assertThat(lateMemberRanking)
                 .extracting(TeamMemberResult::getMemberId)
                 .containsExactly(member1.getId(), member3.getId());
@@ -349,10 +349,10 @@ public class TeamServiceIntegrationTest {
         teamService.analyzeLateTimeResult(schedule1.getId());
 
         //then
-        Team testTeam = teamQueryRepository.findById(team.getId()).orElse(null);
-        assertThat(testTeam).isNotNull();
+        Team resultTeam = teamQueryRepository.findById(team.getId()).orElse(null);
+        assertThat(resultTeam).isNotNull();
 
-        List<TeamMemberResult> lateMemberRanking = objectMapper.readValue(testTeam.getTeamResult().getLateTimeResult(), TeamLateTimeResult.class).getMembers();
+        List<TeamMemberResult> lateMemberRanking = objectMapper.readValue(resultTeam.getTeamResult().getLateTimeResult(), TeamLateTimeResult.class).getMembers();
         assertThat(lateMemberRanking)
                 .extracting(TeamMemberResult::getPreviousRank)
                 .containsExactly(3, 2, 1);
@@ -409,10 +409,10 @@ public class TeamServiceIntegrationTest {
 
         //then
         //member1:0 member2:100 member3:200
-        Team findTeam = teamQueryRepository.findById(team.getId()).orElse(null);
-        assertThat(findTeam).isNotNull();
+        Team resultTeam = teamQueryRepository.findById(team.getId()).orElse(null);
+        assertThat(resultTeam).isNotNull();
 
-        List<TeamMemberResult> teamMemberResults = objectMapper.readValue(findTeam.getTeamResult().getTeamBettingResult(), TeamBettingResult.class).getMembers();
+        List<TeamMemberResult> teamMemberResults = objectMapper.readValue(resultTeam.getTeamResult().getTeamBettingResult(), TeamBettingResult.class).getMembers();
         assertThat(teamMemberResults).hasSize(3);
         assertThat(teamMemberResults)
                 .extracting(TeamMemberResult::getMemberId)
@@ -463,10 +463,10 @@ public class TeamServiceIntegrationTest {
         teamService.analyzeBettingResult(schedule1.getId());
 
         //then
-        Team testTeam = teamQueryRepository.findById(team.getId()).orElse(null);
-        assertThat(testTeam).isNotNull();
+        Team resultTeam = teamQueryRepository.findById(team.getId()).orElse(null);
+        assertThat(resultTeam).isNotNull();
 
-        List<TeamMemberResult> teamMemberResults = objectMapper.readValue(testTeam.getTeamResult().getTeamBettingResult(), TeamBettingResult.class).getMembers();
+        List<TeamMemberResult> teamMemberResults = objectMapper.readValue(resultTeam.getTeamResult().getTeamBettingResult(), TeamBettingResult.class).getMembers();
         assertThat(teamMemberResults)
                 .extracting(TeamMemberResult::getRank)
                 .containsExactly(1, 2, 3);
@@ -523,10 +523,10 @@ public class TeamServiceIntegrationTest {
 
         //then
         //member1: 30, member2: 20, member3: 0
-        Team findTeam = teamQueryRepository.findById(team.getId()).orElse(null);
-        assertThat(findTeam).isNotNull();
+        Team resultTeam = teamQueryRepository.findById(team.getId()).orElse(null);
+        assertThat(resultTeam).isNotNull();
 
-        List<TeamMemberResult> teamMemberResults = objectMapper.readValue(findTeam.getTeamResult().getTeamRacingResult(), TeamRacingResult.class).getMembers();
+        List<TeamMemberResult> teamMemberResults = objectMapper.readValue(resultTeam.getTeamResult().getTeamRacingResult(), TeamRacingResult.class).getMembers();
         assertThat(teamMemberResults).hasSize(3);
         assertThat(teamMemberResults)
                 .extracting(TeamMemberResult::getMemberId)
@@ -585,11 +585,11 @@ public class TeamServiceIntegrationTest {
         teamService.analyzeRacingResult(schedule1.getId());
 
         //then
-        Team findTeam = teamQueryRepository.findById(team.getId()).orElse(null);
-        assertThat(findTeam).isNotNull();
-        System.out.println(findTeam.getTeamResult().getTeamRacingResult());
+        Team resultTeam = teamQueryRepository.findById(team.getId()).orElse(null);
+        assertThat(resultTeam).isNotNull();
+        System.out.println(resultTeam.getTeamResult().getTeamRacingResult());
 
-        List<TeamMemberResult> teamMemberResults = objectMapper.readValue(findTeam.getTeamResult().getTeamRacingResult(), TeamRacingResult.class).getMembers();
+        List<TeamMemberResult> teamMemberResults = objectMapper.readValue(resultTeam.getTeamResult().getTeamRacingResult(), TeamRacingResult.class).getMembers();
         assertThat(teamMemberResults)
                 .extracting(TeamMemberResult::getRank)
                 .containsExactly(1, 2, 3, 4);

--- a/aiku/aiku-main/src/test/java/aiku_main/integration_test/TeamServiceIntegrationTest.java
+++ b/aiku/aiku-main/src/test/java/aiku_main/integration_test/TeamServiceIntegrationTest.java
@@ -1,14 +1,8 @@
 package aiku_main.integration_test;
 
-import aiku_main.dto.team.TeamBettingResult;
-import aiku_main.dto.team.TeamLateTimeResult;
-import aiku_main.dto.team.TeamRacingResult;
-import aiku_main.dto.team.TeamResultMember;
+import aiku_main.dto.team.*;
 import aiku_main.dto.*;
-import aiku_main.dto.team.TeamAddDto;
-import aiku_main.dto.team.TeamDetailResDto;
-import aiku_main.dto.team.TeamEachListResDto;
-import aiku_main.dto.team.TeamMemberResDto;
+import aiku_main.dto.team.TeamResDto;
 import aiku_main.exception.TeamException;
 import aiku_main.repository.MemberRepository;
 import aiku_main.repository.TeamQueryRepository;
@@ -256,10 +250,10 @@ public class TeamServiceIntegrationTest {
 
         //when
         int page = 1;
-        DataResDto<List<TeamEachListResDto>> result = teamService.getTeamList(member1.getId(), page);
+        DataResDto<List<TeamResDto>> result = teamService.getTeamList(member1.getId(), page);
 
         //then
-        List<TeamEachListResDto> data = result.getData();
+        List<TeamResDto> data = result.getData();
         assertThat(data.size()).isEqualTo(3);
         assertThat(data).extracting("groupId").containsExactly(teamC.getId(), teamA.getId(), teamB.getId());
         assertThat(data).extracting("memberSize").containsExactly(3, 1, 2);
@@ -303,7 +297,7 @@ public class TeamServiceIntegrationTest {
         assertThat(findTeam).isNotNull();
 
         TeamLateTimeResult result = objectMapper.readValue(findTeam.getTeamResult().getLateTimeResult(), TeamLateTimeResult.class);
-        List<TeamResultMember> lateMemberRanking = result.getMembers();
+        List<TeamMemberResult> lateMemberRanking = result.getMembers();
         assertThat(lateMemberRanking).extracting("memberId").containsExactly(member1.getId(), member3.getId());
         assertThat(lateMemberRanking).extracting("analysis").containsExactly(-30, -15);
     }
@@ -348,7 +342,7 @@ public class TeamServiceIntegrationTest {
         assertThat(findTeam).isNotNull();
 
         TeamLateTimeResult result = objectMapper.readValue(findTeam.getTeamResult().getLateTimeResult(), TeamLateTimeResult.class);
-        List<TeamResultMember> lateMemberRanking = result.getMembers();
+        List<TeamMemberResult> lateMemberRanking = result.getMembers();
         assertThat(lateMemberRanking).extracting("previousRank").containsExactly(3, 2, 1);
         assertThat(lateMemberRanking).extracting("rank").containsExactly(1, 2, 3);
     }
@@ -399,10 +393,10 @@ public class TeamServiceIntegrationTest {
         //then
         Team findTeam = teamQueryRepository.findById(team.getId()).orElse(null);
         assertThat(findTeam).isNotNull();
-        List<TeamResultMember> teamResultMembers = objectMapper.readValue(findTeam.getTeamResult().getTeamBettingResult(), TeamBettingResult.class)
+        List<TeamMemberResult> teamMemberResults = objectMapper.readValue(findTeam.getTeamResult().getTeamBettingResult(), TeamBettingResult.class)
                 .getMembers();
-        assertThat(teamResultMembers.size()).isEqualTo(3);
-        assertThat(teamResultMembers).extracting("memberId").containsExactly(member3.getId(), member2.getId(), member1.getId());
+        assertThat(teamMemberResults.size()).isEqualTo(3);
+        assertThat(teamMemberResults).extracting("memberId").containsExactly(member3.getId(), member2.getId(), member1.getId());
     }
 
     @Test
@@ -449,10 +443,10 @@ public class TeamServiceIntegrationTest {
         //then
         Team findTeam = teamQueryRepository.findById(team.getId()).orElse(null);
         assertThat(findTeam).isNotNull();
-        List<TeamResultMember> teamResultMembers = objectMapper.readValue(findTeam.getTeamResult().getTeamBettingResult(), TeamBettingResult.class)
+        List<TeamMemberResult> teamMemberResults = objectMapper.readValue(findTeam.getTeamResult().getTeamBettingResult(), TeamBettingResult.class)
                 .getMembers();
-        assertThat(teamResultMembers).extracting("rank").containsExactly(1, 2, 3);
-        assertThat(teamResultMembers).extracting("previousRank").containsExactly(1, -1, 2);
+        assertThat(teamMemberResults).extracting("rank").containsExactly(1, 2, 3);
+        assertThat(teamMemberResults).extracting("previousRank").containsExactly(1, -1, 2);
     }
 
     @Test
@@ -501,10 +495,10 @@ public class TeamServiceIntegrationTest {
         //then
         Team findTeam = teamQueryRepository.findById(team.getId()).orElse(null);
         assertThat(findTeam).isNotNull();
-        List<TeamResultMember> teamResultMembers = objectMapper.readValue(findTeam.getTeamResult().getTeamRacingResult(), TeamRacingResult.class)
+        List<TeamMemberResult> teamMemberResults = objectMapper.readValue(findTeam.getTeamResult().getTeamRacingResult(), TeamRacingResult.class)
                 .getMembers();
-        assertThat(teamResultMembers.size()).isEqualTo(3);
-        assertThat(teamResultMembers).extracting("memberId").containsExactly(member1.getId(), member2.getId(), member3.getId());
+        assertThat(teamMemberResults.size()).isEqualTo(3);
+        assertThat(teamMemberResults).extracting("memberId").containsExactly(member1.getId(), member2.getId(), member3.getId());
     }
 
     @Test
@@ -564,9 +558,9 @@ public class TeamServiceIntegrationTest {
         Team findTeam = teamQueryRepository.findById(team.getId()).orElse(null);
         assertThat(findTeam).isNotNull();
         System.out.println(findTeam.getTeamResult().getTeamRacingResult());
-        List<TeamResultMember> teamResultMembers = objectMapper.readValue(findTeam.getTeamResult().getTeamRacingResult(), TeamRacingResult.class)
+        List<TeamMemberResult> teamMemberResults = objectMapper.readValue(findTeam.getTeamResult().getTeamRacingResult(), TeamRacingResult.class)
                 .getMembers();
-        assertThat(teamResultMembers).extracting("rank").containsExactly(1, 2, 3, 4);
-        assertThat(teamResultMembers).extracting("previousRank").containsExactly(1, 2, 3, -1);
+        assertThat(teamMemberResults).extracting("rank").containsExactly(1, 2, 3, 4);
+        assertThat(teamMemberResults).extracting("previousRank").containsExactly(1, 2, 3, -1);
     }
 }

--- a/aiku/aiku-main/src/test/java/aiku_main/service/TeamServiceTest.java
+++ b/aiku/aiku-main/src/test/java/aiku_main/service/TeamServiceTest.java
@@ -48,7 +48,7 @@ class TeamServiceTest {
         //given
         Member member = new Member("member1");
 
-        when(memberRepository.findById(nullable(Long.class))).thenReturn(Optional.of(member));
+        when(memberRepository.findByIdAndStatus(nullable(Long.class), any())).thenReturn(Optional.of(member));
 
         //when
         TeamAddDto teamDto = new TeamAddDto("team1");
@@ -63,32 +63,10 @@ class TeamServiceTest {
 
         when(teamQueryRepository.existTeamMember(any(), any())).thenReturn(false);
         when(teamQueryRepository.findByIdAndStatus(any(), any())).thenReturn(Optional.of(team));
-        when(memberRepository.findById(nullable(Long.class))).thenReturn(Optional.of(member));
+        when(memberRepository.findByIdAndStatus(nullable(Long.class), any())).thenReturn(Optional.of(member));
 
         //when
         Long resultId = teamService.enterTeam(member.getId(), null);
-    }
-
-    @Test
-    void getTeamDetail() {
-        //given
-        Member member1 = new Member("member1");
-        Member member2 = new Member("member2");
-        Team team = Team.create(member1, "team1");
-        team.addTeamMember(member2);
-
-        when(teamQueryRepository.existTeamMember(any(), any())).thenReturn(true);
-        when(teamQueryRepository.existsById(any())).thenReturn(true);
-        when(teamQueryRepository.findTeamWithMember(any())).thenReturn(Optional.of(team));
-
-        //when
-        TeamDetailResDto result = teamService.getTeamDetail(member1.getId(), team.getId());
-
-        //then
-        assertThat(result.getGroupName()).isEqualTo(team.getTeamName());
-
-        List<TeamMemberResDto> teamMembers = result.getMembers();
-        assertThat(teamMembers).extracting("nickname").containsExactly(member1.getNickname(), member2.getNickname());
     }
 
     @Test

--- a/aiku/aiku-main/src/test/java/aiku_main/service/TeamServiceTest.java
+++ b/aiku/aiku-main/src/test/java/aiku_main/service/TeamServiceTest.java
@@ -4,7 +4,7 @@ import aiku_main.application_event.publisher.TeamEventPublisher;
 import aiku_main.dto.*;
 import aiku_main.dto.team.TeamAddDto;
 import aiku_main.dto.team.TeamDetailResDto;
-import aiku_main.dto.team.TeamEachListResDto;
+import aiku_main.dto.team.TeamResDto;
 import aiku_main.dto.team.TeamMemberResDto;
 import aiku_main.repository.BettingQueryRepository;
 import aiku_main.repository.MemberRepository;
@@ -96,12 +96,12 @@ class TeamServiceTest {
         //given
         Member member1 = new Member("member1");
 
-        List<TeamEachListResDto> data = new ArrayList<>();
+        List<TeamResDto> data = new ArrayList<>();
         when(teamQueryRepository.getTeamList(nullable(Long.class), nullable(Integer.class))).thenReturn(data);
 
         //when
         int page = 3;
-        DataResDto<List<TeamEachListResDto>> result = teamService.getTeamList(member1.getId(), 3);
+        DataResDto<List<TeamResDto>> result = teamService.getTeamList(member1.getId(), 3);
 
         //then
         assertThat(result.getPage()).isEqualTo(3);

--- a/aiku/aiku-main/src/test/java/aiku_main/service/TeamServiceTest.java
+++ b/aiku/aiku-main/src/test/java/aiku_main/service/TeamServiceTest.java
@@ -2,6 +2,10 @@ package aiku_main.service;
 
 import aiku_main.application_event.publisher.TeamEventPublisher;
 import aiku_main.dto.*;
+import aiku_main.dto.team.TeamAddDto;
+import aiku_main.dto.team.TeamDetailResDto;
+import aiku_main.dto.team.TeamEachListResDto;
+import aiku_main.dto.team.TeamMemberResDto;
 import aiku_main.repository.BettingQueryRepository;
 import aiku_main.repository.MemberRepository;
 import aiku_main.repository.ScheduleQueryRepository;


### PR DESCRIPTION
## 관련 이슈 번호

- #131 

<br />

## 작업 사항

- 팀 퇴장 시 퇴장 멤버 표시를 위한 레이싱 결과, 베팅 결과 재분석 로직 추가
- TeamService 리팩토링
- TeamRepository의 join()을 leftjoin()으로 변경
join()이 leftJoin과 같지만 innerJoin으로 착각의 가능성이 있어 명확히 분리
- TeamService통합 테스트 리팩토링 및 설명 주석 추가
- ObjectMapperUtil 클래스를 분리함. ObjectMapper로 직렬화, 역직렬화 하는 코드는 전부 ObjectMapperUtil로 책임 이관

<br />

## 기타 사항
<br />
