### PR TITLE
스케줄 종료 시 레이싱 결과 저장 방식 변경

### DIFF
--- a/aiku/aiku-main/src/main/java/aiku_main/application_event/domain/ScheduleRacing.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/application_event/domain/ScheduleRacing.java
@@ -12,4 +12,5 @@ public class ScheduleRacing {
     private ScheduleRacingMember firstRacer;
     private ScheduleRacingMember secondRacer;
     private int pointAmount;
+    private Long winnerId;
 }

--- a/aiku/aiku-main/src/main/java/aiku_main/service/RacingService.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/service/RacingService.java
@@ -48,7 +48,7 @@ public class RacingService {
                 .map(racing -> {
                     ScheduleRacingMember firstRacer = new ScheduleRacingMember(scheduleMembers.get(racing.getFirstRacer().getId()).getMember());
                     ScheduleRacingMember secondRacer = new ScheduleRacingMember(scheduleMembers.get(racing.getSecondRacer().getId()).getMember());
-                    return new ScheduleRacing(firstRacer, secondRacer, racing.getPointAmount());
+                    return new ScheduleRacing(firstRacer, secondRacer, racing.getPointAmount(), racing.getWinner().getId());
                 }).toList();
 
         ScheduleRacingResult result = new ScheduleRacingResult(scheduleId, racingDtoList);

--- a/aiku/aiku-main/src/test/java/aiku_main/integration_test/RacingServiceTest.java
+++ b/aiku/aiku-main/src/test/java/aiku_main/integration_test/RacingServiceTest.java
@@ -165,5 +165,6 @@ public class RacingServiceTest {
 
         List<ScheduleRacing> data = scheduleRacingResultObj.getData();
         assertThat(data).extracting("firstRacer").extracting("memberId").containsExactly(member1.getId(), member2.getId());
+        assertThat(data.get(0).getWinnerId()).isEqualTo(member1.getId());
     }
 }


### PR DESCRIPTION
## 관련 이슈 번호
<br />

- #143 
## 작업 사항
<br />

- 스케줄 종료 시 레이싱 결과까지 저장하도록 수정
- 테스트 코드 추가
## 기타 사항
<br />
