### PR TITLE
도메인 값 객체에서 엔티티 참조 제거, Long타입의 id로 생성하게 끔 변경

### DIFF
--- a/aiku/aiku-common/src/main/java/common/domain/value_reference/BettingValue.java
+++ b/aiku/aiku-common/src/main/java/common/domain/value_reference/BettingValue.java
@@ -1,21 +1,18 @@
 package common.domain.value_reference;
 
-import common.domain.Betting;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PACKAGE)
 @Embeddable
 public class BettingValue {
 
     @Column(name = "bettingId")
     private Long id;
-
-    public BettingValue(Long id) {
-        this.id = id;
-    }
 }

--- a/aiku/aiku-common/src/main/java/common/domain/value_reference/EventValue.java
+++ b/aiku/aiku-common/src/main/java/common/domain/value_reference/EventValue.java
@@ -1,21 +1,18 @@
 package common.domain.value_reference;
 
-import common.domain.event.CommonEvent;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PACKAGE)
 @Embeddable
 public class EventValue {
 
     @Column(name = "eventId")
     private Long id;
-
-    public EventValue(Long id) {
-        this.id = id;
-    }
 }

--- a/aiku/aiku-common/src/main/java/common/domain/value_reference/MemberValue.java
+++ b/aiku/aiku-common/src/main/java/common/domain/value_reference/MemberValue.java
@@ -1,21 +1,18 @@
 package common.domain.value_reference;
 
-import common.domain.member.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PACKAGE)
 @Embeddable
 public class MemberValue {
 
     @Column(name = "memberId")
     private Long id;
-
-    public MemberValue(Member member) {
-        this.id = member.getId();
-    }
 }

--- a/aiku/aiku-common/src/main/java/common/domain/value_reference/PaymentValue.java
+++ b/aiku/aiku-common/src/main/java/common/domain/value_reference/PaymentValue.java
@@ -1,21 +1,18 @@
 package common.domain.value_reference;
 
-import common.domain.Payment;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PACKAGE)
 @Embeddable
 public class PaymentValue {
 
     @Column(name = "memberId")
     private Long id;
-
-    public PaymentValue(Payment payment) {
-        this.id = payment.getId();
-    }
 }

--- a/aiku/aiku-common/src/main/java/common/domain/value_reference/RacingValue.java
+++ b/aiku/aiku-common/src/main/java/common/domain/value_reference/RacingValue.java
@@ -1,21 +1,18 @@
 package common.domain.value_reference;
 
-import common.domain.Racing;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PACKAGE)
 @Embeddable
 public class RacingValue {
 
     @Column(name = "racingId")
     private Long id;
-
-    public RacingValue(Long id) {
-        this.id = id;
-    }
 }

--- a/aiku/aiku-common/src/main/java/common/domain/value_reference/ScheduleMemberValue.java
+++ b/aiku/aiku-common/src/main/java/common/domain/value_reference/ScheduleMemberValue.java
@@ -1,6 +1,5 @@
 package common.domain.value_reference;
 
-import common.domain.schedule.ScheduleMember;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
@@ -16,8 +15,4 @@ public class ScheduleMemberValue {
 
     @Column(name = "scheduleMemberId")
     private Long id;
-
-    public ScheduleMemberValue(ScheduleMember scheduleMember) {
-        this.id = scheduleMember.getId();
-    }
 }

--- a/aiku/aiku-common/src/main/java/common/domain/value_reference/ScheduleValue.java
+++ b/aiku/aiku-common/src/main/java/common/domain/value_reference/ScheduleValue.java
@@ -1,23 +1,15 @@
 package common.domain.value_reference;
 
-import common.domain.schedule.Schedule;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
+@AllArgsConstructor
 @Embeddable
 public class ScheduleValue {
 
     @Column(name = "scheduleId")
     private Long id;
-
-    public ScheduleValue(Schedule schedule) {
-        this.id = schedule.getId();
-    }
-
-    public ScheduleValue(Long id) {
-        this.id = id;
-    }
 }

--- a/aiku/aiku-common/src/main/java/common/domain/value_reference/ShopProductValue.java
+++ b/aiku/aiku-common/src/main/java/common/domain/value_reference/ShopProductValue.java
@@ -1,21 +1,18 @@
 package common.domain.value_reference;
 
-import common.domain.ShopProduct;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PACKAGE)
 @Embeddable
 public class ShopProductValue {
 
     @Column(name = "shopProductId")
     private Long id;
-
-    public ShopProductValue(Long id) {
-        this.id = id;
-    }
 }

--- a/aiku/aiku-common/src/main/java/common/domain/value_reference/TeamValue.java
+++ b/aiku/aiku-common/src/main/java/common/domain/value_reference/TeamValue.java
@@ -1,26 +1,18 @@
 package common.domain.value_reference;
 
-import common.domain.team.Team;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PACKAGE)
 @Embeddable
 public class TeamValue {
 
     @Column(name = "teamId")
     private Long id;
-
-    //TODO 도메인으로 생성하는 로직 제거
-    public TeamValue(Team team) {
-        this.id = team.getId();
-    }
-
-    public TeamValue(Long id) {
-        this.id = id;
-    }
 }

--- a/aiku/aiku-common/src/main/java/common/domain/value_reference/TitleMemberValue.java
+++ b/aiku/aiku-common/src/main/java/common/domain/value_reference/TitleMemberValue.java
@@ -1,26 +1,18 @@
 package common.domain.value_reference;
 
-import common.domain.schedule.ScheduleMember;
-import common.domain.title.TitleMember;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PACKAGE)
 @Embeddable
 public class TitleMemberValue {
 
     @Column(name = "titleMemberId")
     private Long id;
-
-    public TitleMemberValue(TitleMember titleMember) {
-        this.id = titleMember.getId();
-    }
-
-    public TitleMemberValue(Long id) {
-        this.id = id;
-    }
 }


### PR DESCRIPTION
## 관련 이슈 번호

- #154 

<br />

## 작업 사항

- 생성자에 엔티티를 직접 참조하는 코드 제거, Long타입의 id를 통해 생성하도록 변경
- 생성자를 직접 선언하는 대신 @AllArgsConstructor 어노테이션 활용

<br />

## 기타 사항

- 부수적인 컴파일 오류 각 파트 담당자가 수정해야함

<br />
