### PR TITLE
application event에서 엔티티에 사용되는 값 객체 제거

### DIFF
--- a/aiku/aiku-main/src/main/java/aiku_main/application_event/event/PointChangeEvent.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/application_event/event/PointChangeEvent.java
@@ -1,24 +1,16 @@
 package aiku_main.application_event.event;
 
-import common.domain.member.Member;
-import common.domain.value_reference.MemberValue;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public class PointChangeEvent {
 
-    private MemberValue member;
+    private Long memberId;
     private PointChangeType sign;
     private int pointAmount;
 
     private PointChangeReason reason;
     private Long reasonId;
-
-    public PointChangeEvent(MemberValue member, PointChangeType sign, int pointAmount, PointChangeReason reason, Long reasonId) {
-        this.member = member;
-        this.sign = sign;
-        this.pointAmount = pointAmount;
-        this.reason = reason;
-        this.reasonId = reasonId;
-    }
 }

--- a/aiku/aiku-main/src/main/java/aiku_main/application_event/event/PointChangeFailEvent.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/application_event/event/PointChangeFailEvent.java
@@ -1,24 +1,16 @@
 package aiku_main.application_event.event;
 
-import common.domain.member.Member;
-import common.domain.value_reference.MemberValue;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public class PointChangeFailEvent {
 
-    private MemberValue member;
+    private Long memberId;
     private PointChangeType sign;
     private int pointAmount;
 
     private PointChangeReason reason;
     private Long reasonId;
-
-    public PointChangeFailEvent(MemberValue member, PointChangeType sign, int pointAmount, PointChangeReason reason, Long reasonId) {
-        this.member = member;
-        this.sign = sign;
-        this.pointAmount = pointAmount;
-        this.reason = reason;
-        this.reasonId = reasonId;
-    }
 }

--- a/aiku/aiku-main/src/main/java/aiku_main/application_event/event/ScheduleAutoCloseEvent.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/application_event/event/ScheduleAutoCloseEvent.java
@@ -1,15 +1,11 @@
 package aiku_main.application_event.event;
 
-import common.domain.schedule.Schedule;
-import common.domain.value_reference.ScheduleValue;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public class ScheduleAutoCloseEvent {
 
-    private ScheduleValue schedule;
-
-    public ScheduleAutoCloseEvent(Schedule schedule) {
-        this.schedule = new ScheduleValue(schedule);
-    }
+    private Long scheduleId;
 }

--- a/aiku/aiku-main/src/main/java/aiku_main/application_event/event/ScheduleCloseEvent.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/application_event/event/ScheduleCloseEvent.java
@@ -1,15 +1,11 @@
 package aiku_main.application_event.event;
 
-import common.domain.schedule.Schedule;
-import common.domain.value_reference.ScheduleValue;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public class ScheduleCloseEvent {
 
-    private ScheduleValue schedule;
-
-    public ScheduleCloseEvent(Schedule schedule) {
-        this.schedule = new ScheduleValue(schedule);
-    }
+    private Long scheduleId;
 }

--- a/aiku/aiku-main/src/main/java/aiku_main/application_event/event/ScheduleExitEvent.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/application_event/event/ScheduleExitEvent.java
@@ -1,11 +1,5 @@
 package aiku_main.application_event.event;
 
-import common.domain.schedule.Schedule;
-import common.domain.schedule.ScheduleMember;
-import common.domain.member.Member;
-import common.domain.value_reference.MemberValue;
-import common.domain.value_reference.ScheduleMemberValue;
-import common.domain.value_reference.ScheduleValue;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -13,13 +7,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public class ScheduleExitEvent {
 
-    private MemberValue member;
-    private ScheduleMemberValue scheduleMember;
-    private ScheduleValue schedule;
-
-    public ScheduleExitEvent(Member member, ScheduleMember scheduleMember, Schedule schedule) {
-        this.member = new MemberValue(member);
-        this.scheduleMember = new ScheduleMemberValue(scheduleMember);
-        this.schedule = new ScheduleValue(schedule);
-    }
+    private Long memberId;
+    private Long scheduleMemberId;
+    private Long scheduleId;
 }

--- a/aiku/aiku-main/src/main/java/aiku_main/application_event/event/ScheduleOpenEvent.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/application_event/event/ScheduleOpenEvent.java
@@ -1,16 +1,11 @@
 package aiku_main.application_event.event;
 
-import common.domain.schedule.Schedule;
-import common.domain.value_reference.ScheduleValue;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public class ScheduleOpenEvent {
 
-    private ScheduleValue schedule;
-
-    public ScheduleOpenEvent(Schedule schedule) {
-        this.schedule = new ScheduleValue(schedule);
-    }
+    private Long scheduleId;
 }

--- a/aiku/aiku-main/src/main/java/aiku_main/application_event/event/TeamExitEvent.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/application_event/event/TeamExitEvent.java
@@ -1,20 +1,12 @@
 package aiku_main.application_event.event;
 
-import common.domain.member.Member;
-import common.domain.team.Team;
-import common.domain.value_reference.MemberValue;
-import common.domain.value_reference.TeamValue;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public class TeamExitEvent{
 
-    private MemberValue member;
-    private TeamValue team;
-
-    public TeamExitEvent(Member member, Team team) {
-        this.member = new MemberValue(member);
-        this.team = new TeamValue(team);
-    }
+    private Long memberId;
+    private Long teamId;
 }


### PR DESCRIPTION
## 관련 이슈 번호

- #154 

<br />

## 작업 사항

- application event에서 참조하는 도메인 value object 제거 후 Long 타입의 고유 아이디를 참조하도록 변경

<br />

## 기타 사항
해당 프로젝트에서 도메인 value object는 엔티티가 다른 어그리게이트의 엔티티를 직접 참조하는 대신 값객체를 사용하도록 정의한 클래스이다.
엔티티에 embedded되기 persistence를 import하며 db와 밀접한 관련이 되어 있으므로 이를 이벤트 로직에서 분리한다.
<br />
