### PR TITLE
event publisher에 엔티티 관련 의존 제거 및 컴파일 오류 수정

### DIFF
--- a/aiku/aiku-main/src/main/java/aiku_main/application_event/handler/BettingHandler.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/application_event/handler/BettingHandler.java
@@ -18,19 +18,19 @@ public class BettingHandler {
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleScheduleExitEvent(ScheduleExitEvent event){
-        bettingService.exitSchedule_deleteBettingForBettor(event.getMember().getId(), event.getScheduleMember().getId(), event.getSchedule().getId());
-        bettingService.exitSchedule_deleteBettingForBetee(event.getMember().getId(), event.getScheduleMember().getId(), event.getSchedule().getId());
+        bettingService.exitSchedule_deleteBettingForBettor(event.getMemberId(), event.getScheduleMemberId(), event.getScheduleId());
+        bettingService.exitSchedule_deleteBettingForBetee(event.getMemberId(), event.getScheduleMemberId(), event.getScheduleId());
     }
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void processBettingResult(ScheduleCloseEvent event){
-        bettingService.processBettingResult(event.getSchedule().getId());
+        bettingService.processBettingResult(event.getScheduleId());
     }
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void analyzeScheduleBettingResult(ScheduleCloseEvent event){
-        bettingService.analyzeScheduleBettingResult(event.getSchedule().getId());
+        bettingService.analyzeScheduleBettingResult(event.getScheduleId());
     }
 }

--- a/aiku/aiku-main/src/main/java/aiku_main/application_event/handler/ScheduleHandler.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/application_event/handler/ScheduleHandler.java
@@ -7,7 +7,6 @@ import aiku_main.application_event.event.TeamExitEvent;
 import aiku_main.service.ScheduleService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
-import org.springframework.core.annotation.Order;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
@@ -19,31 +18,33 @@ public class ScheduleHandler {
 
     private final ScheduleService scheduleService;
 
+    @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleTeamExitEvent(TeamExitEvent event){
-        scheduleService.exitAllScheduleInTeam(event.getMember().getId(), event.getTeam().getId());
+        scheduleService.exitAllScheduleInTeam(event.getMemberId(), event.getTeamId());
     }
 
+    @Async
     @EventListener
     public void handleScheduleOpenEvent(ScheduleOpenEvent event){
-        scheduleService.openSchedule(event.getSchedule().getId());
+        scheduleService.openSchedule(event.getScheduleId());
     }
 
     @Async
     @EventListener
     public void closeScheduleAuto(ScheduleAutoCloseEvent event){
-        scheduleService.closeScheduleAuto(event.getSchedule().getId());
+        scheduleService.closeScheduleAuto(event.getScheduleId());
     }
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void processSchedulePoint(ScheduleCloseEvent event){
-        scheduleService.processScheduleResultPoint(event.getSchedule().getId());
+        scheduleService.processScheduleResultPoint(event.getScheduleId());
     }
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void analyzeScheduleArrivalResult(ScheduleCloseEvent event) {
-        scheduleService.analyzeScheduleArrivalResult(event.getSchedule().getId());
+        scheduleService.analyzeScheduleArrivalResult(event.getScheduleId());
     }
 }

--- a/aiku/aiku-main/src/main/java/aiku_main/application_event/handler/TeamHandler.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/application_event/handler/TeamHandler.java
@@ -18,24 +18,24 @@ public class TeamHandler {
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void analyzeLateTimeResult(ScheduleCloseEvent event){
-        teamService.analyzeLateTimeResult(event.getSchedule().getId());
+        teamService.analyzeLateTimeResult(event.getScheduleId());
     }
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void analyzeBettingResult(ScheduleCloseEvent event){
-        teamService.analyzeBettingResult(event.getSchedule().getId());
+        teamService.analyzeBettingResult(event.getScheduleId());
     }
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void analyzeRacingResult(ScheduleCloseEvent event){
-        teamService.analyzeRacingResult(event.getSchedule().getId());
+        teamService.analyzeRacingResult(event.getScheduleId());
     }
 
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void updateLateTimeResultOfExitMember(TeamExitEvent event) {
-        teamService.updateTeamResultOfExitMember(event.getMember().getId(), event.getTeam().getId());
+        teamService.updateTeamResultOfExitMember(event.getMemberId(), event.getTeamId());
     }
 }

--- a/aiku/aiku-main/src/main/java/aiku_main/application_event/publisher/PointChangeEventPublisher.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/application_event/publisher/PointChangeEventPublisher.java
@@ -3,8 +3,6 @@ package aiku_main.application_event.publisher;
 import aiku_main.application_event.event.PointChangeEvent;
 import aiku_main.application_event.event.PointChangeReason;
 import aiku_main.application_event.event.PointChangeType;
-import common.domain.member.Member;
-import common.domain.value_reference.MemberValue;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
@@ -15,13 +13,13 @@ public class PointChangeEventPublisher {
 
     private final ApplicationEventPublisher publisher;
 
-    public void publish(MemberValue member, PointChangeType changeType, int pointAmount, PointChangeReason reason, Long reasonId){
-        PointChangeEvent event = new PointChangeEvent(member, changeType, pointAmount, reason, reasonId);
+    public void publish(Long memberId, PointChangeType changeType, int pointAmount, PointChangeReason reason, Long reasonId){
+        PointChangeEvent event = new PointChangeEvent(memberId, changeType, pointAmount, reason, reasonId);
         publisher.publishEvent(event);
     }
 
-    public void consumerPublish(MemberValue member, PointChangeType changeType, int pointAmount, PointChangeReason reason, Long reasonId){
-        PointChangeEvent event = new PointChangeEvent(member, changeType, pointAmount, reason, reasonId);
+    public void consumerPublish(Long memberId, PointChangeType changeType, int pointAmount, PointChangeReason reason, Long reasonId){
+        PointChangeEvent event = new PointChangeEvent(memberId, changeType, pointAmount, reason, reasonId);
         publisher.publishEvent(event);
     }
 

--- a/aiku/aiku-main/src/main/java/aiku_main/application_event/publisher/PointChangeFailEventPublisher.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/application_event/publisher/PointChangeFailEventPublisher.java
@@ -1,11 +1,8 @@
 package aiku_main.application_event.publisher;
 
-import aiku_main.application_event.event.PointChangeEvent;
 import aiku_main.application_event.event.PointChangeFailEvent;
 import aiku_main.application_event.event.PointChangeReason;
 import aiku_main.application_event.event.PointChangeType;
-import common.domain.member.Member;
-import common.domain.value_reference.MemberValue;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
@@ -16,8 +13,8 @@ public class PointChangeFailEventPublisher {
 
     private final ApplicationEventPublisher publisher;
 
-    public void publish(MemberValue member, PointChangeType changeType, int pointAmount, PointChangeReason reason, Long reasonId){
-        PointChangeFailEvent event = new PointChangeFailEvent(member, changeType, pointAmount, reason, reasonId);
+    public void publish(Long memberId, PointChangeType changeType, int pointAmount, PointChangeReason reason, Long reasonId){
+        PointChangeFailEvent event = new PointChangeFailEvent(memberId, changeType, pointAmount, reason, reasonId);
         publisher.publishEvent(event);
     }
 

--- a/aiku/aiku-main/src/main/java/aiku_main/application_event/publisher/ScheduleEventPublisher.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/application_event/publisher/ScheduleEventPublisher.java
@@ -4,10 +4,6 @@ import aiku_main.application_event.event.ScheduleAutoCloseEvent;
 import aiku_main.application_event.event.ScheduleCloseEvent;
 import aiku_main.application_event.event.ScheduleExitEvent;
 import aiku_main.application_event.event.ScheduleOpenEvent;
-import common.domain.schedule.Schedule;
-import common.domain.schedule.ScheduleMember;
-import common.domain.member.Member;
-import common.domain.team.Team;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
@@ -18,23 +14,23 @@ public class ScheduleEventPublisher {
 
     private final ApplicationEventPublisher publisher;
 
-    public void publishScheduleExitEvent(Member member, ScheduleMember scheduleMember, Schedule schedule){
-        ScheduleExitEvent event = new ScheduleExitEvent(member, scheduleMember, schedule);
+    public void publishScheduleExitEvent(Long memberId, Long scheduleMemberId, Long scheduleId){
+        ScheduleExitEvent event = new ScheduleExitEvent(memberId, scheduleMemberId, scheduleId);
         publisher.publishEvent(event);
     }
 
-    public void publishScheduleOpenEvent(Schedule schedule){
-        ScheduleOpenEvent event = new ScheduleOpenEvent(schedule);
+    public void publishScheduleOpenEvent(Long scheduleId){
+        ScheduleOpenEvent event = new ScheduleOpenEvent(scheduleId);
         publisher.publishEvent(event);
     }
 
-    public void publishScheduleAutoCloseEvent(Schedule schedule){
-        ScheduleAutoCloseEvent event = new ScheduleAutoCloseEvent(schedule);
+    public void publishScheduleAutoCloseEvent(Long scheduleId){
+        ScheduleAutoCloseEvent event = new ScheduleAutoCloseEvent(scheduleId);
         publisher.publishEvent(event);
     }
 
-    public void publishScheduleCloseEvent(Schedule schedule){
-        ScheduleCloseEvent event = new ScheduleCloseEvent(schedule);
+    public void publishScheduleCloseEvent(Long scheduleId){
+        ScheduleCloseEvent event = new ScheduleCloseEvent(scheduleId);
         publisher.publishEvent(event);
     }
 }

--- a/aiku/aiku-main/src/main/java/aiku_main/application_event/publisher/TeamEventPublisher.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/application_event/publisher/TeamEventPublisher.java
@@ -1,8 +1,6 @@
 package aiku_main.application_event.publisher;
 
 import aiku_main.application_event.event.TeamExitEvent;
-import common.domain.member.Member;
-import common.domain.team.Team;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
@@ -13,9 +11,8 @@ public class TeamEventPublisher {
 
     private final ApplicationEventPublisher publisher;
 
-    public void publishTeamExitEvent(Member member, Team team){
-        TeamExitEvent event = new TeamExitEvent(member, team);
+    public void publishTeamExitEvent(Long memberId, Long teamId){
+        TeamExitEvent event = new TeamExitEvent(memberId, teamId);
         publisher.publishEvent(event);
     }
-
 }

--- a/aiku/aiku-main/src/main/java/aiku_main/repository/BettingQueryRepositoryCustom.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/repository/BettingQueryRepositoryCustom.java
@@ -3,7 +3,6 @@ package aiku_main.repository;
 import aiku_main.repository.dto.TeamBettingResultMemberDto;
 import common.domain.Betting;
 import common.domain.ExecStatus;
-import common.domain.value_reference.ScheduleMemberValue;
 
 import java.util.List;
 import java.util.Map;
@@ -12,7 +11,7 @@ public interface BettingQueryRepositoryCustom {
 
     List<Betting> findBettingsInSchedule(Long scheduleId, ExecStatus bettingStatus);
 
-    boolean existBettorInSchedule(ScheduleMemberValue bettor, Long scheduleId);
+    boolean existBettorInSchedule(Long scheduleMemberIdOfBettor, Long scheduleId);
 
     Map<Long, List<TeamBettingResultMemberDto>> findMemberTermBettingsInTeam(Long teamId);
 }

--- a/aiku/aiku-main/src/main/java/aiku_main/repository/BettingQueryRepositoryCustomImpl.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/repository/BettingQueryRepositoryCustomImpl.java
@@ -7,7 +7,6 @@ import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import common.domain.Betting;
 import common.domain.ExecStatus;
-import common.domain.value_reference.ScheduleMemberValue;
 import lombok.RequiredArgsConstructor;
 
 import java.util.List;
@@ -28,13 +27,13 @@ public class BettingQueryRepositoryCustomImpl implements BettingQueryRepositoryC
     private final JPAQueryFactory query;
 
     @Override
-    public boolean existBettorInSchedule(ScheduleMemberValue bettor, Long scheduleId) {
+    public boolean existBettorInSchedule(Long scheduleMemberIdOfBettor, Long scheduleId) {
         Long count = query
                 .select(betting.count())
                 .from(betting)
-                .join(scheduleMember).on(scheduleMember.id.eq(bettor.getId()))
+                .join(scheduleMember).on(scheduleMember.id.eq(scheduleMemberIdOfBettor))
                 .where(scheduleMember.schedule.id.eq(scheduleId),
-                        betting.bettor.id.eq(bettor.getId()),
+                        betting.bettor.id.eq(scheduleMemberIdOfBettor),
                         betting.status.eq(ALIVE))
                 .fetchOne();
 

--- a/aiku/aiku-main/src/main/java/aiku_main/repository/ScheduleQueryRepositoryCustom.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/repository/ScheduleQueryRepositoryCustom.java
@@ -28,6 +28,8 @@ public interface ScheduleQueryRepositoryCustom {
     List<ScheduleMember> findWaitScheduleMemberWithScheduleInTeam(Long memberId, Long teamId);
     List<ScheduleMember> findScheduleMembersWithMember(Long scheduleId);
 
+    Optional<Long> findScheduleMemberId(Long memberId, Long scheduleId);
+    Optional<Long> findMemberIdOfScheduleMember(Long scheduleMemberId);
     boolean isScheduleOwner(Long memberId, Long scheduleId);
     boolean existScheduleMember(Long memberId, Long scheduleId);
     boolean existPaidScheduleMember(Long memberId, Long scheduleId);

--- a/aiku/aiku-main/src/main/java/aiku_main/repository/ScheduleQueryRepositoryCustomImpl.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/repository/ScheduleQueryRepositoryCustomImpl.java
@@ -224,6 +224,33 @@ public class ScheduleQueryRepositoryCustomImpl implements ScheduleQueryRepositor
     }
 
     @Override
+    public Optional<Long> findScheduleMemberId(Long memberId, Long scheduleId) {
+         Long id = query
+                .select(scheduleMember.id)
+                .from(scheduleMember)
+                .where(
+                        scheduleMember.member.id.eq(memberId),
+                        scheduleMember.schedule.id.eq(scheduleId),
+                        scheduleMember.status.eq(ALIVE)
+                )
+                .fetchOne();
+
+        return Optional.ofNullable(id);
+    }
+
+    @Override
+    public Optional<Long> findMemberIdOfScheduleMember(Long scheduleMemberId) {
+        Long id = query
+                .select(member.id)
+                .from(scheduleMember)
+                .innerJoin(scheduleMember.member, member)
+                .where(scheduleMember.id.eq(scheduleMemberId))
+                .fetchOne();
+
+        return Optional.ofNullable(id);
+    }
+
+    @Override
     public Optional<ScheduleMember> findNextScheduleOwnerWithMember(Long scheduleId, Long prevOwnerScheduleMemberId) {
         ScheduleMember findScheduleMember = query
                 .selectFrom(scheduleMember)

--- a/aiku/aiku-main/src/main/java/aiku_main/service/BettingService.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/service/BettingService.java
@@ -67,7 +67,7 @@ public class BettingService {
         Betting betting = Betting.create(bettor, bettee, bettingDto.getPointAmount());
         bettingQueryRepository.save(betting);
 
-        pointChangeEventPublisher.publish(member, MINUS, bettingDto.getPointAmount(), BETTING, betting.getId());
+        pointChangeEventPublisher.publish(memberId, MINUS, bettingDto.getPointAmount(), BETTING, betting.getId());
 
         return betting.getId();
     }
@@ -83,7 +83,7 @@ public class BettingService {
         //서비스 로직
         betting.setStatus(DELETE);
 
-        pointChangeEventPublisher.publish(member, PLUS, betting.getPointAmount(), BETTING, bettingId);
+        pointChangeEventPublisher.publish(memberId, PLUS, betting.getPointAmount(), BETTING, bettingId);
 
         return betting.getId();
     }
@@ -96,7 +96,7 @@ public class BettingService {
 
         int pointAmount = bettingForBettor.getPointAmount();
         Member member = memberRepository.findById(memberId).orElseThrow();
-        pointChangeEventPublisher.publish(member, PLUS, pointAmount, BETTING_CANCLE, bettingForBettor.getId());
+        pointChangeEventPublisher.publish(memberId, PLUS, pointAmount, BETTING_CANCLE, bettingForBettor.getId());
     }
 
     @Transactional
@@ -130,8 +130,13 @@ public class BettingService {
         if(winBettingCount == 0) {
             for (Betting betting : bettings) {
                 betting.setDraw();
-                pointChangeEventPublisher.publish(scheduleMembers.get(betting.getBettor().getId()).getMember(),
-                        PLUS, betting.getPointAmount(), BETTING, betting.getId());
+                pointChangeEventPublisher.publish(
+                        scheduleMembers.get(betting.getBettor().getId()).getMember().getId(),
+                        PLUS,
+                        betting.getPointAmount(),
+                        BETTING,
+                        betting.getId()
+                );
             }
             return;
         }
@@ -143,8 +148,13 @@ public class BettingService {
             if(scheduleMembers.get(betting.getBetee().getId()).getArrivalTime().equals(latestTime)){
                 int rewardPoint = getBettingRewardPoint(betting.getPointAmount(), winnerPointAmount, bettingPointAmount);
                 betting.setWin(rewardPoint);
-                pointChangeEventPublisher.publish(scheduleMembers.get(betting.getBettor().getId()).getMember(),
-                        PLUS, rewardPoint, BETTING, betting.getId());
+                pointChangeEventPublisher.publish(
+                        scheduleMembers.get(betting.getBettor().getId()).getMember().getId(),
+                        PLUS,
+                        rewardPoint,
+                        BETTING,
+                        betting.getId()
+                );
             }else {
                 betting.setLose();
             }

--- a/aiku/aiku-main/src/main/java/aiku_main/service/BettingService.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/service/BettingService.java
@@ -18,7 +18,6 @@ import common.domain.schedule.ScheduleMember;
 import common.domain.member.Member;
 import common.domain.value_reference.ScheduleMemberValue;
 import common.exception.NotEnoughPoint;
-import common.exception.PaidMemberLimitException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -50,64 +49,79 @@ public class BettingService {
 
     @Transactional
     public Long addBetting(Long memberId, Long scheduleId, BettingAddDto bettingDto){
-        //검증 로직
         Member member = findMember(memberId);
-        checkExistSchedule(scheduleId);
         checkScheduleWait(scheduleId);
-        checkPaidScheduleMember(member.getId(), scheduleId);
-        checkPaidScheduleMember(bettingDto.getBeteeMemberId(), scheduleId);
 
-        ScheduleMemberValue bettor = new ScheduleMemberValue(findScheduleMember(member.getId(), scheduleId));
-        ScheduleMemberValue bettee = new ScheduleMemberValue(findScheduleMember(bettingDto.getBeteeMemberId(), scheduleId));
+        ScheduleMemberValue bettor = new ScheduleMemberValue(findScheduleMemberId(member.getId(), scheduleId));
+        ScheduleMemberValue bettee = new ScheduleMemberValue(findScheduleMemberId(bettingDto.getBeteeMemberId(), scheduleId));
 
-        checkAlreadyHasBetting(bettor, scheduleId);
+        checkAlreadyHasBetting(bettor.getId(), scheduleId);
         checkEnoughPoint(member, bettingDto.getPointAmount());
 
-        //서비스 로직
         Betting betting = Betting.create(bettor, bettee, bettingDto.getPointAmount());
         bettingQueryRepository.save(betting);
 
-        pointChangeEventPublisher.publish(memberId, MINUS, bettingDto.getPointAmount(), BETTING, betting.getId());
+        pointChangeEventPublisher.publish(
+                memberId,
+                MINUS,
+                bettingDto.getPointAmount(),
+                BETTING,
+                betting.getId()
+        );
 
         return betting.getId();
     }
 
     @Transactional
     public Long cancelBetting(Long memberId, Long scheduleId, Long bettingId){
-        //검증 로직
-        Member member = findMember(memberId);
-        ScheduleMember bettor = findScheduleMember(member.getId(), scheduleId);
+        ScheduleMember bettor = findScheduleMember(memberId, scheduleId);
         Betting betting = findBettingById(bettingId);
         checkBettingMember(betting, bettor);
 
-        //서비스 로직
         betting.setStatus(DELETE);
 
-        pointChangeEventPublisher.publish(memberId, PLUS, betting.getPointAmount(), BETTING, bettingId);
+        pointChangeEventPublisher.publish(
+                memberId,
+                PLUS,
+                betting.getPointAmount(),
+                BETTING,
+                bettingId
+        );
 
         return betting.getId();
     }
 
-    //==이벤트 핸들러==
     @Transactional
     public void exitSchedule_deleteBettingForBettor(Long memberId, Long scheduleMemberId, Long scheduleId){
-        Betting bettingForBettor = bettingQueryRepository.findByBettorIdAndStatus(scheduleMemberId, ALIVE).orElse(null);
-        bettingForBettor.setStatus(DELETE);
+        bettingQueryRepository.findByBettorIdAndStatus(scheduleMemberId, ALIVE)
+                .ifPresent((betting) -> {
+                    betting.setStatus(DELETE);
 
-        int pointAmount = bettingForBettor.getPointAmount();
-        Member member = memberRepository.findById(memberId).orElseThrow();
-        pointChangeEventPublisher.publish(memberId, PLUS, pointAmount, BETTING_CANCLE, bettingForBettor.getId());
+                    pointChangeEventPublisher.publish(
+                            memberId,
+                            PLUS,
+                            betting.getPointAmount(),
+                            BETTING_CANCLE,
+                            betting.getId()
+                    );
+                });
     }
 
     @Transactional
     public void exitSchedule_deleteBettingForBetee(Long memberId, Long scheduleMemberId, Long scheduleId){
-        Betting bettingForBetee = bettingQueryRepository.findByBeteeIdAndStatus(scheduleMemberId, ALIVE).orElse(null);
-        bettingForBetee.setStatus(DELETE);
+        bettingQueryRepository.findByBeteeIdAndStatus(scheduleMemberId, ALIVE)
+                .ifPresent((betting) -> {
+                    betting.setStatus(DELETE);
 
-        int pointAmount = bettingForBetee.getPointAmount();
-        Member bettor = scheduleQueryRepository.findScheduleMemberWithMemberById(bettingForBetee.getBettor().getId()).orElseThrow()
-                .getMember();
-        pointChangeEventPublisher.publish(bettor, PLUS, pointAmount, BETTING_CANCLE, bettingForBetee.getId());
+                    Long memberIdOfBettor = scheduleQueryRepository.findMemberIdOfScheduleMember(betting.getBettor().getId()).orElseThrow();
+                    pointChangeEventPublisher.publish(
+                            memberIdOfBettor,
+                            PLUS,
+                            betting.getPointAmount(),
+                            BETTING_CANCLE,
+                            betting.getId()
+                    );
+                });
     }
 
     @Transactional
@@ -209,6 +223,7 @@ public class BettingService {
                 .map(betting -> {
                     ScheduleBettingMember bettor = new ScheduleBettingMember(scheduleMembers.get(betting.getBettor().getId()).getMember());
                     ScheduleBettingMember betee = new ScheduleBettingMember(scheduleMembers.get(betting.getBetee().getId()).getMember());
+
                     return new ScheduleBetting(bettor, betee, betting.getPointAmount());
                 }).toList();
 
@@ -222,31 +237,23 @@ public class BettingService {
         }
     }
 
-    //==* 기타 메서드 *==
     private Member findMember(Long memberId){
         return memberRepository.findById(memberId).orElseThrow();
     }
 
     private Betting findBettingById(Long bettingId){
-        Betting betting = bettingQueryRepository.findByIdAndStatus(bettingId, ALIVE).orElse(null);
-        if (betting == null) {
-            throw new BettingException(NO_SUCH_BETTING);
-        }
-        return betting;
-    }
-
-    private void checkExistSchedule(Long scheduleId){
-        if (!scheduleQueryRepository.existsByIdAndStatus(scheduleId, ALIVE)) {
-            throw new ScheduleException(NO_SUCH_SCHEDULE);
-        }
+        return bettingQueryRepository.findByIdAndStatus(bettingId, ALIVE)
+                .orElseThrow(() -> new BettingException(NO_SUCH_BETTING));
     }
 
     private ScheduleMember findScheduleMember(Long memberId, Long scheduleId) {
-        ScheduleMember scheduleMember = scheduleQueryRepository.findScheduleMember(memberId, scheduleId).orElse(null);
-        if (scheduleMember == null) {
-            throw new ScheduleException(NOT_IN_SCHEDULE);
-        }
-        return scheduleMember;
+        return scheduleQueryRepository.findScheduleMember(memberId, scheduleId)
+                .orElseThrow(() -> new ScheduleException(NOT_IN_SCHEDULE));
+    }
+
+    private Long findScheduleMemberId(Long memberId, Long scheduleId) {
+        return scheduleQueryRepository.findScheduleMemberId(memberId, scheduleId)
+                .orElseThrow(() -> new ScheduleException(NOT_IN_SCHEDULE));
     }
 
     private void checkScheduleWait(Long scheduleId) {
@@ -255,15 +262,9 @@ public class BettingService {
         }
     }
 
-    private void checkAlreadyHasBetting(ScheduleMemberValue bettor, Long scheduleId) {
-        if(bettingQueryRepository.existBettorInSchedule(bettor, scheduleId)){
+    private void checkAlreadyHasBetting(Long scheduleMemberIdOfBettor, Long scheduleId) {
+        if(bettingQueryRepository.existBettorInSchedule(scheduleMemberIdOfBettor, scheduleId)){
             throw new BettingException(ALREADY_IN_BETTING);
-        }
-    }
-
-    private void checkPaidScheduleMember(Long memberId, Long scheduleId){
-        if(!scheduleQueryRepository.existPaidScheduleMember(memberId, scheduleId)){
-            throw new PaidMemberLimitException();
         }
     }
 

--- a/aiku/aiku-main/src/main/java/aiku_main/service/TeamService.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/service/TeamService.java
@@ -75,7 +75,7 @@ public class TeamService {
         TeamMember teamMember = findTeamMember(memberId, teamId);
         team.removeTeamMember(teamMember);
 
-        teamEventPublisher.publishTeamExitEvent(member, team);
+        teamEventPublisher.publishTeamExitEvent(memberId, teamId);
 
         return team.getId();
     }

--- a/aiku/aiku-main/src/test/java/aiku_main/service/BettingServiceIntegrationTest.java
+++ b/aiku/aiku-main/src/test/java/aiku_main/service/BettingServiceIntegrationTest.java
@@ -72,8 +72,14 @@ class BettingServiceIntegrationTest {
         em.persist(freeMember);
         em.persist(noScheduleMember);
 
-        schedule1 = Schedule.create(member1, null, "schedule1", LocalDateTime.now(),
-                new Location("loc1", 1.0, 1.0), 1000);
+        schedule1 = Schedule.create(
+                member1,
+                null,
+                "schedule1",
+                LocalDateTime.now(),
+                new Location("loc1", 1.0, 1.0),
+                1000
+        );
         schedule1.addScheduleMember(member2, false, 1000);
         schedule1.addScheduleMember(member3, false, 1000);
         schedule1.addScheduleMember(freeMember, false, 0);
@@ -109,35 +115,39 @@ class BettingServiceIntegrationTest {
 
         //when
         BettingAddDto bettingDto = new BettingAddDto(member2.getId(), 0);
-        assertThatThrownBy(() -> bettingService.addBetting(member1.getId(), schedule1.getId(), bettingDto)).isInstanceOf(ScheduleException.class);
+        assertThatThrownBy(() -> bettingService.addBetting(member1.getId(), schedule1.getId(), bettingDto))
+                .isInstanceOf(ScheduleException.class);
     }
 
     @Test
     void 베팅_등록_스케줄멤버x() {
         //when
         BettingAddDto bettingDto = new BettingAddDto(member2.getId(), 0);
-        assertThatThrownBy(() -> bettingService.addBetting(noScheduleMember.getId(), schedule1.getId(), bettingDto)).isInstanceOf(BaseException.class);
+        assertThatThrownBy(() -> bettingService.addBetting(noScheduleMember.getId(), schedule1.getId(), bettingDto))
+                .isInstanceOf(BaseException.class);
     }
 
     @Test
     void 베팅_등록_깍두기멤버() {
         //when
         BettingAddDto bettingDto = new BettingAddDto(freeMember.getId(), 0);
-        assertThatThrownBy(() -> bettingService.addBetting(noScheduleMember.getId(), schedule1.getId(), bettingDto)).isInstanceOf(PaidMemberLimitException.class);
+        assertThatThrownBy(() -> bettingService.addBetting(noScheduleMember.getId(), schedule1.getId(), bettingDto))
+                .isInstanceOf(PaidMemberLimitException.class);
     }
 
     @Test
     void 베팅_등록_중복() {
         //given
-        ScheduleMember bettor = scheduleQueryRepository.findScheduleMember(member1.getId(), schedule1.getId()).orElse(null);
-        ScheduleMember betee = scheduleQueryRepository.findScheduleMember(member2.getId(), schedule1.getId()).orElse(null);
+        Long ScheduleMemberIdOfBettor = scheduleQueryRepository.findScheduleMemberId(member1.getId(), schedule1.getId()).orElseThrow();
+        Long ScheduleMemberIdOfBetee = scheduleQueryRepository.findScheduleMemberId(member2.getId(), schedule1.getId()).orElseThrow();
 
-        Betting betting = Betting.create(new ScheduleMemberValue(bettor), new ScheduleMemberValue(betee), 0);
+        Betting betting = Betting.create(new ScheduleMemberValue(ScheduleMemberIdOfBettor), new ScheduleMemberValue(ScheduleMemberIdOfBetee), 0);
         em.persist(betting);
 
         //when
         BettingAddDto bettingDto = new BettingAddDto(member2.getId(), 0);
-        assertThatThrownBy(() -> bettingService.addBetting(member1.getId(), schedule1.getId(), bettingDto)).isInstanceOf(BettingException.class);
+        assertThatThrownBy(() -> bettingService.addBetting(member1.getId(), schedule1.getId(), bettingDto))
+                .isInstanceOf(BettingException.class);
     }
 
     @Test
@@ -146,16 +156,17 @@ class BettingServiceIntegrationTest {
         BettingAddDto bettingDto = new BettingAddDto(member2.getId(), 1000);
 
         //then
-        assertThatThrownBy(() -> bettingService.addBetting(member1.getId(), schedule1.getId(), bettingDto)).isInstanceOf(NotEnoughPoint.class);
+        assertThatThrownBy(() -> bettingService.addBetting(member1.getId(), schedule1.getId(), bettingDto))
+                .isInstanceOf(NotEnoughPoint.class);
     }
 
     @Test
     void 베팅_취소() {
         //given
-        ScheduleMember bettor = scheduleQueryRepository.findScheduleMember(member1.getId(), schedule1.getId()).orElseThrow();
-        ScheduleMember betee = scheduleQueryRepository.findScheduleMember(member2.getId(), schedule1.getId()).orElseThrow();
+        Long ScheduleMemberIdOfBettor = scheduleQueryRepository.findScheduleMemberId(member1.getId(), schedule1.getId()).orElseThrow();
+        Long ScheduleMemberIdOfBetee = scheduleQueryRepository.findScheduleMemberId(member2.getId(), schedule1.getId()).orElseThrow();
 
-        Betting betting = Betting.create(new ScheduleMemberValue(bettor), new ScheduleMemberValue(betee), 100);
+        Betting betting = Betting.create(new ScheduleMemberValue(ScheduleMemberIdOfBettor), new ScheduleMemberValue(ScheduleMemberIdOfBetee), 100);
         em.persist(betting);
 
         //when
@@ -170,37 +181,39 @@ class BettingServiceIntegrationTest {
     @Test
     void 베팅_취소_중복() {
         //given
-        ScheduleMember bettor = scheduleQueryRepository.findScheduleMember(member1.getId(), schedule1.getId()).orElseThrow();
-        ScheduleMember betee = scheduleQueryRepository.findScheduleMember(member2.getId(), schedule1.getId()).orElseThrow();
+        Long ScheduleMemberIdOfBettor = scheduleQueryRepository.findScheduleMemberId(member1.getId(), schedule1.getId()).orElseThrow();
+        Long ScheduleMemberIdOfBetee = scheduleQueryRepository.findScheduleMemberId(member2.getId(), schedule1.getId()).orElseThrow();
 
-        Betting betting = Betting.create(new ScheduleMemberValue(bettor), new ScheduleMemberValue(betee), 100);
+        Betting betting = Betting.create(new ScheduleMemberValue(ScheduleMemberIdOfBettor), new ScheduleMemberValue(ScheduleMemberIdOfBetee), 100);
         em.persist(betting);
 
         //when
         bettingService.cancelBetting(member1.getId(), schedule1.getId(), betting.getId());
-        assertThatThrownBy(() -> bettingService.cancelBetting(member1.getId(), schedule1.getId(), betting.getId())).isInstanceOf(BettingException.class);
+        assertThatThrownBy(() -> bettingService.cancelBetting(member1.getId(), schedule1.getId(), betting.getId()))
+                .isInstanceOf(BettingException.class);
     }
 
     @Test
     void 베팅_취소_베터x() {
         //given
-        ScheduleMember bettor = scheduleQueryRepository.findScheduleMember(member1.getId(), schedule1.getId()).orElseThrow();
-        ScheduleMember betee = scheduleQueryRepository.findScheduleMember(member2.getId(), schedule1.getId()).orElseThrow();
+        Long ScheduleMemberIdOfBettor = scheduleQueryRepository.findScheduleMemberId(member1.getId(), schedule1.getId()).orElseThrow();
+        Long ScheduleMemberIdOfBetee = scheduleQueryRepository.findScheduleMemberId(member2.getId(), schedule1.getId()).orElseThrow();
 
-        Betting betting = Betting.create(new ScheduleMemberValue(bettor), new ScheduleMemberValue(betee), 100);
+        Betting betting = Betting.create(new ScheduleMemberValue(ScheduleMemberIdOfBettor), new ScheduleMemberValue(ScheduleMemberIdOfBetee), 100);
         em.persist(betting);
 
         //when
-        assertThatThrownBy(() -> bettingService.cancelBetting(member2.getId(), schedule1.getId(), betting.getId())).isInstanceOf(BettingException.class);
+        assertThatThrownBy(() -> bettingService.cancelBetting(member2.getId(), schedule1.getId(), betting.getId()))
+                .isInstanceOf(BettingException.class);
     }
 
     @Test
     void 베팅_취소_스케줄멤버x() {
         //given
-        ScheduleMember bettor = scheduleQueryRepository.findScheduleMember(member1.getId(), schedule1.getId()).orElseThrow();
-        ScheduleMember betee = scheduleQueryRepository.findScheduleMember(member2.getId(), schedule1.getId()).orElseThrow();
+        Long ScheduleMemberIdOfBettor = scheduleQueryRepository.findScheduleMemberId(member1.getId(), schedule1.getId()).orElseThrow();
+        Long ScheduleMemberIdOfBetee = scheduleQueryRepository.findScheduleMemberId(member2.getId(), schedule1.getId()).orElseThrow();
 
-        Betting betting = Betting.create(new ScheduleMemberValue(bettor), new ScheduleMemberValue(betee), 100);
+        Betting betting = Betting.create(new ScheduleMemberValue(ScheduleMemberIdOfBettor), new ScheduleMemberValue(ScheduleMemberIdOfBetee), 100);
         em.persist(betting);
 
         //when
@@ -210,14 +223,14 @@ class BettingServiceIntegrationTest {
     @Test
     void 이벤트핸들러_스케줄퇴장_퇴장멤버가_베터인_베팅제거(){
         //given
-        ScheduleMember bettor = scheduleQueryRepository.findScheduleMember(member1.getId(), schedule1.getId()).orElseThrow();
-        ScheduleMember betee = scheduleQueryRepository.findScheduleMember(member2.getId(), schedule1.getId()).orElseThrow();
+        Long ScheduleMemberIdOfBettor = scheduleQueryRepository.findScheduleMemberId(member1.getId(), schedule1.getId()).orElseThrow();
+        Long ScheduleMemberIdOfBetee = scheduleQueryRepository.findScheduleMemberId(member2.getId(), schedule1.getId()).orElseThrow();
 
-        Betting betting = Betting.create(new ScheduleMemberValue(bettor), new ScheduleMemberValue(betee), 100);
+        Betting betting = Betting.create(new ScheduleMemberValue(ScheduleMemberIdOfBettor), new ScheduleMemberValue(ScheduleMemberIdOfBetee), 100);
         em.persist(betting);
 
         //when
-        bettingService.exitSchedule_deleteBettingForBettor(member1.getId(), bettor.getId(), schedule1.getId());
+        bettingService.exitSchedule_deleteBettingForBettor(member1.getId(), ScheduleMemberIdOfBettor, schedule1.getId());
 
         //then
         Betting findBetting = bettingQueryRepository.findById(betting.getId()).orElse(null);
@@ -228,14 +241,14 @@ class BettingServiceIntegrationTest {
     @Test
     void 이벤트핸들러_스케줄퇴장_퇴장멤버가_베티인_베팅제거(){
         //given
-        ScheduleMember bettor = scheduleQueryRepository.findScheduleMember(member1.getId(), schedule1.getId()).orElseThrow();
-        ScheduleMember betee = scheduleQueryRepository.findScheduleMember(member2.getId(), schedule1.getId()).orElseThrow();
+        Long ScheduleMemberIdOfBettor = scheduleQueryRepository.findScheduleMemberId(member1.getId(), schedule1.getId()).orElseThrow();
+        Long ScheduleMemberIdOfBetee = scheduleQueryRepository.findScheduleMemberId(member2.getId(), schedule1.getId()).orElseThrow();
 
-        Betting betting = Betting.create(new ScheduleMemberValue(bettor), new ScheduleMemberValue(betee), 100);
+        Betting betting = Betting.create(new ScheduleMemberValue(ScheduleMemberIdOfBettor), new ScheduleMemberValue(ScheduleMemberIdOfBetee), 100);
         em.persist(betting);
 
         //when
-        bettingService.exitSchedule_deleteBettingForBettor(member2.getId(), bettor.getId(), schedule1.getId());
+        bettingService.exitSchedule_deleteBettingForBettor(member2.getId(), ScheduleMemberIdOfBettor, schedule1.getId());
 
         //then
         Betting findBetting = bettingQueryRepository.findById(betting.getId()).orElse(null);
@@ -246,12 +259,12 @@ class BettingServiceIntegrationTest {
     @Test
     void 이벤트핸들러_베팅_결과_계산_지각자x_전원환급(){
         //given
-        ScheduleMember scheduleMember1 = scheduleQueryRepository.findScheduleMember(member1.getId(), schedule1.getId()).orElseThrow();
-        ScheduleMember scheduleMember2 = scheduleQueryRepository.findScheduleMember(member2.getId(), schedule1.getId()).orElseThrow();
-        ScheduleMember scheduleMember3 = scheduleQueryRepository.findScheduleMember(member3.getId(), schedule1.getId()).orElseThrow();
+        Long scheduleMemberId1 = scheduleQueryRepository.findScheduleMemberId(member1.getId(), schedule1.getId()).orElseThrow();
+        Long scheduleMemberId2 = scheduleQueryRepository.findScheduleMemberId(member2.getId(), schedule1.getId()).orElseThrow();
+        Long scheduleMemberId3 = scheduleQueryRepository.findScheduleMemberId(member3.getId(), schedule1.getId()).orElseThrow();
 
-        Betting betting1 = Betting.create(new ScheduleMemberValue(scheduleMember1), new ScheduleMemberValue(scheduleMember3), 100);
-        Betting betting2 = Betting.create(new ScheduleMemberValue(scheduleMember2), new ScheduleMemberValue(scheduleMember3), 200);
+        Betting betting1 = Betting.create(new ScheduleMemberValue(scheduleMemberId1), new ScheduleMemberValue(scheduleMemberId3), 100);
+        Betting betting2 = Betting.create(new ScheduleMemberValue(scheduleMemberId2), new ScheduleMemberValue(scheduleMemberId3), 200);
         em.persist(betting1);
         em.persist(betting2);
 
@@ -265,20 +278,24 @@ class BettingServiceIntegrationTest {
 
         //then
         List<Betting> bettings = bettingQueryRepository.findBettingsInSchedule(schedule1.getId(), TERM);
-        assertThat(bettings).extracting("rewardPointAmount").contains(100, 200);
-        assertThat(bettings).extracting("isWinner").contains(false, false);
+        assertThat(bettings)
+                .extracting(Betting::getRewardPointAmount)
+                .contains(100, 200);
+        assertThat(bettings)
+                .extracting(Betting::isWinner)
+                .contains(false, false);
     }
 
     @Test
     void 이벤트핸들러_베팅_결과_계산(){
         //given
-        ScheduleMember scheduleMember1 = scheduleQueryRepository.findScheduleMember(member1.getId(), schedule1.getId()).orElseThrow();
-        ScheduleMember scheduleMember2 = scheduleQueryRepository.findScheduleMember(member2.getId(), schedule1.getId()).orElseThrow();
-        ScheduleMember scheduleMember3 = scheduleQueryRepository.findScheduleMember(member3.getId(), schedule1.getId()).orElseThrow();
+        Long scheduleMemberId1 = scheduleQueryRepository.findScheduleMemberId(member1.getId(), schedule1.getId()).orElseThrow();
+        Long scheduleMemberId2 = scheduleQueryRepository.findScheduleMemberId(member2.getId(), schedule1.getId()).orElseThrow();
+        Long scheduleMemberId3 = scheduleQueryRepository.findScheduleMemberId(member3.getId(), schedule1.getId()).orElseThrow();
 
-        Betting betting1 = Betting.create(new ScheduleMemberValue(scheduleMember1), new ScheduleMemberValue(scheduleMember3), 100);
-        Betting betting2 = Betting.create(new ScheduleMemberValue(scheduleMember2), new ScheduleMemberValue(scheduleMember3), 200);
-        Betting betting3 = Betting.create(new ScheduleMemberValue(scheduleMember3), new ScheduleMemberValue(scheduleMember1), 300);
+        Betting betting1 = Betting.create(new ScheduleMemberValue(scheduleMemberId1), new ScheduleMemberValue(scheduleMemberId3), 100);
+        Betting betting2 = Betting.create(new ScheduleMemberValue(scheduleMemberId2), new ScheduleMemberValue(scheduleMemberId3), 200);
+        Betting betting3 = Betting.create(new ScheduleMemberValue(scheduleMemberId3), new ScheduleMemberValue(scheduleMemberId1), 300);
         em.persist(betting1);
         em.persist(betting2);
         em.persist(betting3);
@@ -294,20 +311,24 @@ class BettingServiceIntegrationTest {
         //then
         List<Betting> bettings = bettingQueryRepository.findBettingsInSchedule(schedule1.getId(), TERM);
         assertThat(bettings.size()).isEqualTo(3);
-        assertThat(bettings).extracting("rewardPointAmount").contains(200, 400, 0);
-        assertThat(bettings).extracting("isWinner").containsExactly(true, true, false);
+        assertThat(bettings)
+                .extracting(Betting::getRewardPointAmount)
+                .contains(200, 400, 0);
+        assertThat(bettings)
+                .extracting(Betting::isWinner)
+                .containsExactly(true, true, false);
     }
 
     @Test
     void 이벤트핸들러_베팅_결과_계산_꼴찌_여러명(){
         //given
-        ScheduleMember scheduleMember1 = scheduleQueryRepository.findScheduleMember(member1.getId(), schedule1.getId()).orElseThrow();
-        ScheduleMember scheduleMember2 = scheduleQueryRepository.findScheduleMember(member2.getId(), schedule1.getId()).orElseThrow();
-        ScheduleMember scheduleMember3 = scheduleQueryRepository.findScheduleMember(member3.getId(), schedule1.getId()).orElseThrow();
+        Long scheduleMemberId1 = scheduleQueryRepository.findScheduleMemberId(member1.getId(), schedule1.getId()).orElseThrow();
+        Long scheduleMemberId2 = scheduleQueryRepository.findScheduleMemberId(member2.getId(), schedule1.getId()).orElseThrow();
+        Long scheduleMemberId3 = scheduleQueryRepository.findScheduleMemberId(member3.getId(), schedule1.getId()).orElseThrow();
 
-        Betting betting1 = Betting.create(new ScheduleMemberValue(scheduleMember1), new ScheduleMemberValue(scheduleMember3), 100);
-        Betting betting2 = Betting.create(new ScheduleMemberValue(scheduleMember2), new ScheduleMemberValue(scheduleMember2), 300);
-        Betting betting3 = Betting.create(new ScheduleMemberValue(scheduleMember3), new ScheduleMemberValue(scheduleMember1), 200);
+        Betting betting1 = Betting.create(new ScheduleMemberValue(scheduleMemberId1), new ScheduleMemberValue(scheduleMemberId3), 100);
+        Betting betting2 = Betting.create(new ScheduleMemberValue(scheduleMemberId2), new ScheduleMemberValue(scheduleMemberId2), 300);
+        Betting betting3 = Betting.create(new ScheduleMemberValue(scheduleMemberId3), new ScheduleMemberValue(scheduleMemberId1), 200);
         em.persist(betting1);
         em.persist(betting2);
         em.persist(betting3);
@@ -322,20 +343,24 @@ class BettingServiceIntegrationTest {
 
         //then
         List<Betting> bettings = bettingQueryRepository.findBettingsInSchedule(schedule1.getId(), TERM);
-        assertThat(bettings).extracting("rewardPointAmount").contains(200, 400, 0);
-        assertThat(bettings).extracting("isWinner").containsExactly(true, false, true);
+        assertThat(bettings)
+                .extracting(Betting::getRewardPointAmount)
+                .contains(200, 400, 0);
+        assertThat(bettings)
+                .extracting(Betting::isWinner)
+                .containsExactly(true, false, true);
     }
 
     @Test
     void 이벤트핸들러_베팅_결과_분석() throws JsonProcessingException {
         //given
-        ScheduleMember scheduleMember1 = scheduleQueryRepository.findScheduleMember(member1.getId(), schedule1.getId()).orElseThrow();
-        ScheduleMember scheduleMember2 = scheduleQueryRepository.findScheduleMember(member2.getId(), schedule1.getId()).orElseThrow();
-        ScheduleMember scheduleMember3 = scheduleQueryRepository.findScheduleMember(member3.getId(), schedule1.getId()).orElseThrow();
+        Long scheduleMemberId1 = scheduleQueryRepository.findScheduleMemberId(member1.getId(), schedule1.getId()).orElseThrow();
+        Long scheduleMemberId2 = scheduleQueryRepository.findScheduleMemberId(member2.getId(), schedule1.getId()).orElseThrow();
+        Long scheduleMemberId3 = scheduleQueryRepository.findScheduleMemberId(member3.getId(), schedule1.getId()).orElseThrow();
 
-        Betting betting1 = Betting.create(new ScheduleMemberValue(scheduleMember1), new ScheduleMemberValue(scheduleMember3), 100);
-        Betting betting2 = Betting.create(new ScheduleMemberValue(scheduleMember2), new ScheduleMemberValue(scheduleMember3), 200);
-        Betting betting3 = Betting.create(new ScheduleMemberValue(scheduleMember3), new ScheduleMemberValue(scheduleMember1), 300);
+        Betting betting1 = Betting.create(new ScheduleMemberValue(scheduleMemberId1), new ScheduleMemberValue(scheduleMemberId3), 100);
+        Betting betting2 = Betting.create(new ScheduleMemberValue(scheduleMemberId2), new ScheduleMemberValue(scheduleMemberId3), 200);
+        Betting betting3 = Betting.create(new ScheduleMemberValue(scheduleMemberId3), new ScheduleMemberValue(scheduleMemberId1), 300);
         betting1.setWin(1000);
         betting2.setDraw();
         betting3.setLose();
@@ -350,9 +375,12 @@ class BettingServiceIntegrationTest {
         Schedule findSchedule = scheduleQueryRepository.findById(schedule1.getId()).orElse(null);
         assertThat(findSchedule).isNotNull();
 
-        List<ScheduleBetting> bettingResults = objectMapper.readValue(findSchedule.getScheduleResult().getScheduleBettingResult(), ScheduleBettingResult.class)
-                .getData();
-        assertThat(bettingResults).extracting("bettor").extracting("memberId").contains(member1.getId(), member2.getId(), member3.getId());
-        assertThat(bettingResults).extracting("pointAmount").contains(100, 200, 300);
+        List<ScheduleBetting> bettingResults = objectMapper.readValue(findSchedule.getScheduleResult().getScheduleBettingResult(), ScheduleBettingResult.class).getData();
+        assertThat(bettingResults)
+                .extracting((scheduleBetting) -> scheduleBetting.getBettor().getMemberId())
+                .contains(member1.getId(), member2.getId(), member3.getId());
+        assertThat(bettingResults)
+                .extracting(ScheduleBetting::getPointAmount)
+                .contains(100, 200, 300);
     }
 }

--- a/aiku/aiku-main/src/test/java/aiku_main/service/ScheduleServiceTest.java
+++ b/aiku/aiku-main/src/test/java/aiku_main/service/ScheduleServiceTest.java
@@ -433,9 +433,9 @@ public class ScheduleServiceTest {
         schedule.addScheduleMember(member3, false, scheduleEnterPoint);
         em.persist(schedule);
 
-        ScheduleMember scheduleMember1 = scheduleQueryRepository.findScheduleMember(member1.getId(), schedule.getId()).orElseThrow();
-        ScheduleMember scheduleMember2 = scheduleQueryRepository.findScheduleMember(member2.getId(), schedule.getId()).orElseThrow();
-        Betting betting = Betting.create(new ScheduleMemberValue(scheduleMember1), new ScheduleMemberValue(scheduleMember2), 100);
+        Long scheduleMemberId1 = scheduleQueryRepository.findScheduleMemberId(member1.getId(), schedule.getId()).orElseThrow();
+        Long scheduleMemberId2 = scheduleQueryRepository.findScheduleMemberId(member2.getId(), schedule.getId()).orElseThrow();
+        Betting betting = Betting.create(new ScheduleMemberValue(scheduleMemberId1), new ScheduleMemberValue(scheduleMemberId2), 100);
         em.persist(betting);
 
         //when
@@ -672,7 +672,7 @@ public class ScheduleServiceTest {
         LocalDateTime now = LocalDateTime.now().plusDays(3);
         Schedule schedule1 = Schedule.create(
                 member1,
-                new TeamValue(team1),
+                new TeamValue(team1.getId()),
                 "sche1",
                 now.plusDays(3),
                 new Location("loc", 1.0, 1.0),
@@ -680,7 +680,7 @@ public class ScheduleServiceTest {
         );
         Schedule schedule2 = Schedule.create(
                 member1,
-                new TeamValue(team2),
+                new TeamValue(team2.getId()),
                 "sche1",
                 now.plusDays(3),
                 new Location("loc", 1.0, 1.0),
@@ -688,7 +688,7 @@ public class ScheduleServiceTest {
         );
         Schedule schedule3 = Schedule.create(
                 member1,
-                new TeamValue(team2),
+                new TeamValue(team2.getId()),
                 "sche1",
                 now.plusDays(4),
                 new Location("loc", 1.0, 1.0),
@@ -939,7 +939,7 @@ public class ScheduleServiceTest {
     Schedule createSchedule(Member member, Team team){
         return Schedule.create(
                 member, 
-                new TeamValue(team), 
+                new TeamValue(team.getId()),
                 UUID.randomUUID().toString(), 
                 LocalDateTime.now().plusHours(3),
                 new Location(UUID.randomUUID().toString(), random.nextDouble(), random.nextDouble()),


### PR DESCRIPTION
## 관련 이슈 번호

- #154 

<br />

## 작업 사항

- event handler에 엔티티 참조, 도메인 값객체 참조 제거
- 변경으로 인한 컴파일 오류 제거
- BettingService의 중복된 검증 로직 제거 및 코드 스타일 리팩토링

<br />

## 기타 사항
<br />
