### PR TITLE
테스트 실패 해결

### DIFF
--- a/aiku/aiku-main/src/test/java/aiku_main/service/RacingServiceTest.java
+++ b/aiku/aiku-main/src/test/java/aiku_main/service/RacingServiceTest.java
@@ -1,6 +1,7 @@
 package aiku_main.service;
 
 import aiku_main.application_event.domain.ScheduleRacing;
+import aiku_main.application_event.domain.ScheduleRacingMember;
 import aiku_main.application_event.domain.ScheduleRacingResult;
 import aiku_main.repository.RacingQueryRepository;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -163,7 +164,7 @@ public class RacingServiceTest {
         }
 
         List<ScheduleRacing> data = scheduleRacingResultObj.getData();
-        assertThat(data).extracting("firstRacer").extracting("memberId").containsExactly(member1.getId(), member2.getId());
-        assertThat(data.get(0).getWinnerId()).isEqualTo(member1.getId());
+        assertThat(data).extracting(ScheduleRacing::getFirstRacer).extracting(ScheduleRacingMember::getMemberId).containsExactly(member1.getId(), member2.getId());
+        assertThat(data.get(0).getWinnerId()).isEqualTo(scheduleMember1.getId());
     }
 }


### PR DESCRIPTION
## 관련 이슈 번호
<br />

- #154 
## 작업 사항
<br />

- 레이싱 분석 클래스의 winnerId가 memberId가 아닌 scheduleMemberId를 받아야 함
## 기타 사항
<br />
