### PR TITLE
dto 패키지의 하위 패키지 betting, schedule, team 생성

### DIFF
--- a/aiku/aiku-main/src/main/java/aiku_main/controller/BettingController.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/controller/BettingController.java
@@ -1,6 +1,6 @@
 package aiku_main.controller;
 
-import aiku_main.dto.BettingAddDto;
+import aiku_main.dto.betting.BettingAddDto;
 import aiku_main.service.BettingService;
 import common.response.BaseResponse;
 import common.response.BaseResultDto;

--- a/aiku/aiku-main/src/main/java/aiku_main/dto/betting/BettingAddDto.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/dto/betting/BettingAddDto.java
@@ -1,4 +1,4 @@
-package aiku_main.dto;
+package aiku_main.dto.betting;
 
 import aiku_main.controller.validation.ValidPointAmount;
 import jakarta.validation.constraints.Min;

--- a/aiku/aiku-main/src/main/java/aiku_main/dto/betting/ScheduleBetting.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/dto/betting/ScheduleBetting.java
@@ -1,4 +1,4 @@
-package aiku_main.application_event.domain;
+package aiku_main.dto.betting;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/aiku/aiku-main/src/main/java/aiku_main/dto/betting/ScheduleBettingMember.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/dto/betting/ScheduleBettingMember.java
@@ -1,4 +1,4 @@
-package aiku_main.application_event.domain;
+package aiku_main.dto.betting;
 
 import aiku_main.dto.MemberProfileResDto;
 import common.domain.member.Member;

--- a/aiku/aiku-main/src/main/java/aiku_main/dto/betting/ScheduleBettingResult.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/dto/betting/ScheduleBettingResult.java
@@ -1,4 +1,4 @@
-package aiku_main.application_event.domain;
+package aiku_main.dto.betting;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/aiku/aiku-main/src/main/java/aiku_main/dto/schedule/MemberScheduleListEachResDto.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/dto/schedule/MemberScheduleListEachResDto.java
@@ -20,9 +20,14 @@ public class MemberScheduleListEachResDto {
     private ExecStatus scheduleStatus;
 
     @QueryProjection
-    public MemberScheduleListEachResDto(Long groupId, String groupName, Long scheduleId, String scheduleName,
-                                        LocationDto location, LocalDateTime scheduleTime,
-                                      ExecStatus scheduleStatus, int memberCount) {
+    public MemberScheduleListEachResDto(Long groupId,
+                                        String groupName,
+                                        Long scheduleId,
+                                        String scheduleName,
+                                        LocationDto location,
+                                        LocalDateTime scheduleTime,
+                                        ExecStatus scheduleStatus,
+                                        int memberCount) {
         this.groupId = groupId;
         this.groupName = groupName;
         this.scheduleId = scheduleId;

--- a/aiku/aiku-main/src/main/java/aiku_main/dto/schedule/ScheduleAddDto.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/dto/schedule/ScheduleAddDto.java
@@ -16,7 +16,8 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 public class ScheduleAddDto {
 
-    @NotBlank @Size(max = 15)
+    @Size(max = 15)
+    @NotBlank
     private String scheduleName;
     @Valid
     private LocationDto location;

--- a/aiku/aiku-main/src/main/java/aiku_main/dto/schedule/ScheduleArrivalMember.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/dto/schedule/ScheduleArrivalMember.java
@@ -1,11 +1,9 @@
-package aiku_main.application_event.domain;
+package aiku_main.dto.schedule;
 
 import aiku_main.dto.MemberProfileResDto;
 import com.querydsl.core.annotations.QueryProjection;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor

--- a/aiku/aiku-main/src/main/java/aiku_main/dto/schedule/ScheduleArrivalResult.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/dto/schedule/ScheduleArrivalResult.java
@@ -1,4 +1,4 @@
-package aiku_main.application_event.domain;
+package aiku_main.dto.schedule;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/aiku/aiku-main/src/main/java/aiku_main/dto/schedule/ScheduleMemberResDto.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/dto/schedule/ScheduleMemberResDto.java
@@ -15,7 +15,12 @@ public class ScheduleMemberResDto {
     private boolean isBetee;
 
     @QueryProjection
-    public ScheduleMemberResDto(Long memberId, String nickname, MemberProfileResDto memberProfile, boolean isOwner, int point, Long beteeId) {
+    public ScheduleMemberResDto(Long memberId,
+                                String nickname,
+                                MemberProfileResDto memberProfile,
+                                boolean isOwner,
+                                int point,
+                                Long beteeId) {
         this.memberId = memberId;
         this.nickname = nickname;
         this.memberProfile = memberProfile;

--- a/aiku/aiku-main/src/main/java/aiku_main/dto/schedule/SchedulePreviewResDto.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/dto/schedule/SchedulePreviewResDto.java
@@ -16,8 +16,11 @@ public class SchedulePreviewResDto {
     private ScheduleOwnerResDto owner;
 
     @QueryProjection
-
-    public SchedulePreviewResDto(Long scheduleId, String scheduleName, LocalDateTime scheduleTime, LocationDto location, ScheduleOwnerResDto owner) {
+    public SchedulePreviewResDto(Long scheduleId,
+                                 String scheduleName,
+                                 LocalDateTime scheduleTime,
+                                 LocationDto location,
+                                 ScheduleOwnerResDto owner) {
         this.scheduleId = scheduleId;
         this.scheduleName = scheduleName;
         this.scheduleTime = scheduleTime;

--- a/aiku/aiku-main/src/main/java/aiku_main/dto/schedule/ScheduleUpdateDto.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/dto/schedule/ScheduleUpdateDto.java
@@ -16,7 +16,8 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 public class ScheduleUpdateDto {
 
-    @NotBlank @Size(max = 15)
+    @Size(max = 15)
+    @NotBlank
     public String scheduleName;
     @Valid
     public LocationDto location;

--- a/aiku/aiku-main/src/main/java/aiku_main/dto/schedule/TeamScheduleListEachResDto.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/dto/schedule/TeamScheduleListEachResDto.java
@@ -25,8 +25,12 @@ public class TeamScheduleListEachResDto {
     List<Long> membersIdList;
 
     @QueryProjection
-    public TeamScheduleListEachResDto(Long scheduleId, String scheduleName, LocationDto location, LocalDateTime scheduleTime,
-                                      ExecStatus scheduleStatus, String membersIdStringList) {
+    public TeamScheduleListEachResDto(Long scheduleId,
+                                      String scheduleName,
+                                      LocationDto location,
+                                      LocalDateTime scheduleTime,
+                                      ExecStatus scheduleStatus,
+                                      String membersIdStringList) {
         this.scheduleId = scheduleId;
         this.scheduleName = scheduleName;
         this.location = location;

--- a/aiku/aiku-main/src/main/java/aiku_main/dto/schedule/TeamScheduleListResDto.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/dto/schedule/TeamScheduleListResDto.java
@@ -1,11 +1,12 @@
 package aiku_main.dto.schedule;
 
-import common.domain.team.Team;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.util.List;
 
 @Getter
+@AllArgsConstructor
 public class TeamScheduleListResDto {
 
     private int page;
@@ -13,12 +14,4 @@ public class TeamScheduleListResDto {
     private int runSchedule;
     private int waitSchedule;
     private List<TeamScheduleListEachResDto> data;
-
-    public TeamScheduleListResDto(Team team, int page, int runSchedule, int waitSchedule, List<TeamScheduleListEachResDto> data) {
-        this.groupId = team.getId();
-        this.page = page;
-        this.runSchedule = runSchedule;
-        this.waitSchedule = waitSchedule;
-        this.data = data;
-    }
 }

--- a/aiku/aiku-main/src/main/java/aiku_main/dto/team/TeamAddDto.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/dto/team/TeamAddDto.java
@@ -11,6 +11,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class TeamAddDto {
 
-    @NotBlank @Size(max = 15)
+    @Size(max = 15)
+    @NotBlank
     private String groupName;
 }

--- a/aiku/aiku-main/src/main/java/aiku_main/dto/team/TeamDetailResDto.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/dto/team/TeamDetailResDto.java
@@ -1,19 +1,15 @@
 package aiku_main.dto.team;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.util.List;
 
 @Getter
+@AllArgsConstructor
 public class TeamDetailResDto {
 
     private Long groupId;
     private String groupName;
     private List<TeamMemberResDto> members;
-
-    public TeamDetailResDto(Long groupId, String groupName, List<TeamMemberResDto> members) {
-        this.groupId = groupId;
-        this.groupName = groupName;
-        this.members = members;
-    }
 }

--- a/aiku/aiku-main/src/main/java/aiku_main/dto/team/TeamMemberResult.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/dto/team/TeamMemberResult.java
@@ -9,7 +9,8 @@ import lombok.Setter;
 
 import static common.domain.Status.ALIVE;
 
-@Getter @Setter
+@Getter
+@Setter
 @NoArgsConstructor
 public class TeamMemberResult {
 
@@ -22,7 +23,11 @@ public class TeamMemberResult {
     private boolean isTeamMember;
 
     @QueryProjection
-    public TeamMemberResult(Long memberId, String nickname, MemberProfileResDto memberProfile, int analysis, Status isTeamMember) {
+    public TeamMemberResult(Long memberId,
+                            String nickname,
+                            MemberProfileResDto memberProfile,
+                            int analysis,
+                            Status isTeamMember) {
         this.memberId = memberId;
         this.nickname = nickname;
         this.memberProfile = memberProfile;
@@ -30,7 +35,12 @@ public class TeamMemberResult {
         this.isTeamMember = isTeamMember == ALIVE ? true : false;
     }
 
-    public TeamMemberResult(Long memberId, String nickname, MemberProfileResDto memberProfile, int analysis, int previousRank, Status isTeamMember) {
+    public TeamMemberResult(Long memberId,
+                            String nickname,
+                            MemberProfileResDto memberProfile,
+                            int analysis,
+                            int previousRank,
+                            Status isTeamMember) {
         this.memberId = memberId;
         this.nickname = nickname;
         this.memberProfile = memberProfile;

--- a/aiku/aiku-main/src/main/java/aiku_main/repository/ScheduleQueryRepositoryCustom.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/repository/ScheduleQueryRepositoryCustom.java
@@ -1,6 +1,6 @@
 package aiku_main.repository;
 
-import aiku_main.application_event.domain.ScheduleArrivalMember;
+import aiku_main.dto.schedule.ScheduleArrivalMember;
 import aiku_main.dto.*;
 import aiku_main.dto.schedule.MemberScheduleListEachResDto;
 import aiku_main.dto.schedule.ScheduleMemberResDto;

--- a/aiku/aiku-main/src/main/java/aiku_main/repository/ScheduleQueryRepositoryCustomImpl.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/repository/ScheduleQueryRepositoryCustomImpl.java
@@ -1,6 +1,6 @@
 package aiku_main.repository;
 
-import aiku_main.application_event.domain.ScheduleArrivalMember;
+import aiku_main.dto.schedule.ScheduleArrivalMember;
 import aiku_main.dto.*;
 import aiku_main.dto.schedule.*;
 import com.querydsl.core.types.Projections;

--- a/aiku/aiku-main/src/main/java/aiku_main/service/BettingService.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/service/BettingService.java
@@ -1,10 +1,10 @@
 package aiku_main.service;
 
-import aiku_main.application_event.domain.ScheduleBetting;
-import aiku_main.application_event.domain.ScheduleBettingMember;
-import aiku_main.application_event.domain.ScheduleBettingResult;
+import aiku_main.dto.betting.ScheduleBetting;
+import aiku_main.dto.betting.ScheduleBettingMember;
+import aiku_main.dto.betting.ScheduleBettingResult;
 import aiku_main.application_event.publisher.PointChangeEventPublisher;
-import aiku_main.dto.BettingAddDto;
+import aiku_main.dto.betting.BettingAddDto;
 import aiku_main.exception.BettingException;
 import aiku_main.exception.ScheduleException;
 import aiku_main.repository.BettingQueryRepository;

--- a/aiku/aiku-main/src/main/java/aiku_main/service/ScheduleService.java
+++ b/aiku/aiku-main/src/main/java/aiku_main/service/ScheduleService.java
@@ -1,7 +1,7 @@
 package aiku_main.service;
 
-import aiku_main.application_event.domain.ScheduleArrivalMember;
-import aiku_main.application_event.domain.ScheduleArrivalResult;
+import aiku_main.dto.schedule.ScheduleArrivalMember;
+import aiku_main.dto.schedule.ScheduleArrivalResult;
 import aiku_main.application_event.publisher.PointChangeEventPublisher;
 import aiku_main.application_event.publisher.ScheduleEventPublisher;
 import aiku_main.dto.*;
@@ -219,7 +219,7 @@ public class ScheduleService {
         int runSchedule = scheduleQueryRepository.countTeamScheduleByScheduleStatus(teamId, ExecStatus.RUN, dateCond);
         int waitSchedule = scheduleQueryRepository.countTeamScheduleByScheduleStatus(teamId, ExecStatus.WAIT, dateCond);
 
-        return new TeamScheduleListResDto(team, page, runSchedule, waitSchedule, scheduleList);
+        return new TeamScheduleListResDto(page, teamId, runSchedule, waitSchedule, scheduleList);
     }
 
     public MemberScheduleListResDto getMemberScheduleList(Long memberId, SearchDateCond dateCond, int page) {

--- a/aiku/aiku-main/src/test/java/aiku_main/controller/BettingControllerTest.java
+++ b/aiku/aiku-main/src/test/java/aiku_main/controller/BettingControllerTest.java
@@ -1,6 +1,6 @@
 package aiku_main.controller;
 
-import aiku_main.dto.BettingAddDto;
+import aiku_main.dto.betting.BettingAddDto;
 import aiku_main.service.BettingService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;

--- a/aiku/aiku-main/src/test/java/aiku_main/service/BettingServiceIntegrationTest.java
+++ b/aiku/aiku-main/src/test/java/aiku_main/service/BettingServiceIntegrationTest.java
@@ -1,8 +1,8 @@
 package aiku_main.service;
 
-import aiku_main.application_event.domain.ScheduleBetting;
-import aiku_main.application_event.domain.ScheduleBettingResult;
-import aiku_main.dto.BettingAddDto;
+import aiku_main.dto.betting.ScheduleBetting;
+import aiku_main.dto.betting.ScheduleBettingResult;
+import aiku_main.dto.betting.BettingAddDto;
 import aiku_main.exception.BettingException;
 import aiku_main.exception.ScheduleException;
 import aiku_main.repository.BettingQueryRepository;
@@ -17,7 +17,6 @@ import common.domain.schedule.ScheduleMember;
 import common.domain.value_reference.ScheduleMemberValue;
 import common.exception.BaseException;
 import common.exception.NotEnoughPoint;
-import common.exception.PaidMemberLimitException;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;

--- a/aiku/aiku-main/src/test/java/aiku_main/service/ScheduleServiceTest.java
+++ b/aiku/aiku-main/src/test/java/aiku_main/service/ScheduleServiceTest.java
@@ -1,7 +1,7 @@
 package aiku_main.service;
 
-import aiku_main.application_event.domain.ScheduleArrivalMember;
-import aiku_main.application_event.domain.ScheduleArrivalResult;
+import aiku_main.dto.schedule.ScheduleArrivalMember;
+import aiku_main.dto.schedule.ScheduleArrivalResult;
 import aiku_main.dto.*;
 import aiku_main.dto.schedule.*;
 import aiku_main.exception.ScheduleException;


### PR DESCRIPTION
## 관련 이슈 번호

- #162 

<br />

## 작업 사항

- dto 패키지에 schedule, team, betting 서비스에서 사용하는 dto를 하위 패키지로 분리해줌
- application_event.domain에 있었던 분석 dto들을 dto 패키지로 이동
- 생성자를 롬복을 통해 생략해줌
- 파라미터가 5개 이상이면 줄바꿈을 통해 가독성 개선

<br />

## 기타 사항
<br />
