### PR TITLE
허용된 요청의 경우 필터 로직을 수행하지 않도록 수정

### DIFF
--- a/aiku/aiku-gateway/src/main/java/gateway/security/JwtSecurityUtils.java
+++ b/aiku/aiku-gateway/src/main/java/gateway/security/JwtSecurityUtils.java
@@ -1,0 +1,33 @@
+package gateway.security;
+
+import org.springframework.http.HttpMethod;
+import org.springframework.util.AntPathMatcher;
+
+import java.util.Arrays;
+
+public class JwtSecurityUtils {
+    public static final String[] ALL_METHOD_PERMIT_ALL_PATHS = {
+            "/login/sign-in/**",
+            "/login/refresh",
+            "/error",
+            "/users/nickname",
+    };
+
+    public static final String[] POST_METHOD_PERMIT_ALL_PATHS = {
+            "/users"
+    };
+
+    private static final AntPathMatcher pathMatcher = new AntPathMatcher();
+
+    public static boolean isPermitAllPath(String path, HttpMethod method) {
+        if (HttpMethod.POST.equals(method)) {
+            return Arrays.stream(POST_METHOD_PERMIT_ALL_PATHS)
+                    .anyMatch(pattern -> pathMatcher.match(pattern, path));
+        }
+
+        return Arrays.stream(ALL_METHOD_PERMIT_ALL_PATHS)
+                .anyMatch(pattern -> pathMatcher.match(pattern, path));
+    }
+
+
+}

--- a/aiku/aiku-gateway/src/main/java/gateway/security/SecurityConfig.java
+++ b/aiku/aiku-gateway/src/main/java/gateway/security/SecurityConfig.java
@@ -28,9 +28,8 @@ public class SecurityConfig {
                 .cors(cors -> cors.disable()) // CORS 비활성화
                 .securityContextRepository(NoOpServerSecurityContextRepository.getInstance()) // 상태 비저장
                 .authorizeExchange(exchange -> exchange
-                        .pathMatchers("/login/sign-in/**", "/login/refresh", "/error").permitAll() // 공개 경로 설정
-                        .pathMatchers(HttpMethod.POST, "/users").permitAll()
-                        .pathMatchers("/users/nickname").permitAll()
+                        .pathMatchers(JwtSecurityUtils.ALL_METHOD_PERMIT_ALL_PATHS).permitAll() // 공개 경로 설정
+                        .pathMatchers(HttpMethod.POST, JwtSecurityUtils.POST_METHOD_PERMIT_ALL_PATHS).permitAll() // 공개 경로 설정
                         .anyExchange().authenticated() // 이외의 모든 요청 인증 필요
                 )
                 .addFilterAt(jwtAuthenticationWebFilter(), SecurityWebFiltersOrder.AUTHENTICATION)


### PR DESCRIPTION
## 관련 이슈 번호
<br />

- #183 
## 작업 사항
<br />

- 허용된 요청을 일반 처리하기 위한 상수, 매칭 로직을 가진 Utils 클래스 추가
- SecurityConfig에서 상수를 사용하도록 변경
- JwtAuthenticationFilter에서 허용된 요청의 경우 필터 로직을 무시하고 다음 체인으로 넘기도록 수정

## 기타 사항
<br />
