### PR TITLE
Map 모듈의 서비스 계층 단위 테스트 작성

### DIFF
--- a/aiku/aiku-map/src/test/java/map/service/map/MapServiceIntegrationTest.java
+++ b/aiku/aiku-map/src/test/java/map/service/map/MapServiceIntegrationTest.java
@@ -1,4 +1,4 @@
-package map.service;
+package map.service.map;
 
 import common.domain.Arrival;
 import common.domain.Location;
@@ -10,7 +10,7 @@ import common.domain.value_reference.TeamValue;
 import jakarta.persistence.EntityManager;
 import map.dto.*;
 import map.exception.ScheduleException;
-import org.assertj.core.api.Assertions;
+import map.service.MapService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,7 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @Transactional
 @SpringBootTest
-public class MapServiceTest {
+public class MapServiceIntegrationTest {
     @Autowired
     EntityManager em;
 

--- a/aiku/aiku-map/src/test/java/map/service/map/MapServiceTest.java
+++ b/aiku/aiku-map/src/test/java/map/service/map/MapServiceTest.java
@@ -55,6 +55,7 @@ public class MapServiceTest {
 
     @Test
     void getScheduleDetail_정상() {
+        // Given
         Location location = new Location("Test Location", 1.0, 2.0);
         Schedule schedule = mock(Schedule.class);
         given(schedule.getLocation()).willReturn(location);
@@ -64,8 +65,10 @@ public class MapServiceTest {
         given(scheduleRepository.existMemberInSchedule(memberId, scheduleId)).willReturn(true);
         given(scheduleRepository.getScheduleMembersInfo(scheduleId)).willReturn(members);
 
+        // When
         ScheduleDetailResDto res = mapService.getScheduleDetail(memberId, scheduleId);
 
+        // Then
         assertThat(res).isNotNull();
         assertThat(res.getScheduleId()).isEqualTo(schedule.getId());
         assertThat(res.getMembers()).isEqualTo(members);
@@ -73,28 +76,35 @@ public class MapServiceTest {
 
     @Test
     void getScheduleDetail_스케줄없음_예외() {
+        // Given
         given(scheduleRepository.findById(scheduleId)).willReturn(Optional.empty());
 
+        // When & Then
         assertThrows(ScheduleException.class, () -> mapService.getScheduleDetail(memberId, scheduleId));
     }
 
     @Test
     void getScheduleDetail_멤버없음_예외() {
+        // Given
         given(scheduleRepository.findById(scheduleId)).willReturn(Optional.of(mock(Schedule.class)));
         given(scheduleRepository.existMemberInSchedule(memberId, scheduleId)).willReturn(false);
 
+        // When & Then
         assertThrows(ScheduleException.class, () -> mapService.getScheduleDetail(memberId, scheduleId));
     }
 
     @Test
     void saveAndSendAllLocation_정상() {
+        // Given
         RealTimeLocationDto dto = new RealTimeLocationDto(1.0, 2.0);
         List<RealTimeLocationResDto> locs = List.of(mock(RealTimeLocationResDto.class));
         given(scheduleRepository.existMemberInSchedule(memberId, scheduleId)).willReturn(true);
         given(scheduleLocationRepository.getScheduleLocations(scheduleId)).willReturn(locs);
 
+        // When
         LocationsResponseDto res = mapService.saveAndSendAllLocation(memberId, scheduleId, dto);
 
+        // Then
         assertThat(res.getCount()).isEqualTo(locs.size());
         assertThat(res.getLocations()).isEqualTo(locs);
         then(scheduleLocationRepository).should().saveLocation(scheduleId, memberId, 1.0, 2.0);
@@ -102,32 +112,40 @@ public class MapServiceTest {
 
     @Test
     void saveAndSendAllLocation_멤버없음_예외() {
+        // Given
         given(scheduleRepository.existMemberInSchedule(memberId, scheduleId)).willReturn(false);
 
+        // When & Then
         assertThrows(ScheduleException.class, () -> mapService.saveAndSendAllLocation(memberId, scheduleId, new RealTimeLocationDto(1.0,2.0)));
     }
 
     @Test
     void getAllLocation_정상() {
+        // Given
         List<RealTimeLocationResDto> locs = List.of(mock(RealTimeLocationResDto.class));
         given(scheduleRepository.existMemberInSchedule(memberId, scheduleId)).willReturn(true);
         given(scheduleLocationRepository.getScheduleLocations(scheduleId)).willReturn(locs);
 
+        // When
         LocationsResponseDto res = mapService.getAllLocation(memberId, scheduleId);
 
+        // Then
         assertThat(res.getCount()).isEqualTo(locs.size());
         assertThat(res.getLocations()).isEqualTo(locs);
     }
 
     @Test
     void getAllLocation_멤버없음_예외() {
+        // Given
         given(scheduleRepository.existMemberInSchedule(memberId, scheduleId)).willReturn(false);
 
+        // When & Then
         assertThrows(ScheduleException.class, () -> mapService.getAllLocation(memberId, scheduleId));
     }
 
     @Test
     void makeMemberArrive_마지막멤버_정상() {
+        // Given
         Schedule schedule = mock(Schedule.class);
         ScheduleMember scheduleMember = mock(ScheduleMember.class);
         Location location = new Location("Location1",1.0, 2.0);
@@ -139,9 +157,11 @@ public class MapServiceTest {
         given(schedule.getScheduleName()).willReturn(scheduleName);
         given(arrivalRepository.isAllMembersInScheduleArrived(scheduleId)).willReturn(true);
 
+        // When
         MemberArrivalDto dto = new MemberArrivalDto(now);
         Long res = mapService.makeMemberArrive(memberId, scheduleId, dto);
 
+        // Then
         assertThat(res).isEqualTo(scheduleId);
         then(arrivalRepository).should().save(any(Arrival.class));
         then(scheduleLocationRepository).should().saveLocation(scheduleId, memberId, 1.0, 2.0);
@@ -152,6 +172,7 @@ public class MapServiceTest {
 
     @Test
     void makeMemberArrive_마지막아닌멤버_정상() {
+        // Given
         Schedule schedule = mock(Schedule.class);
         ScheduleMember scheduleMember = mock(ScheduleMember.class);
         Location location = new Location("Location1", 1.0, 2.0);
@@ -163,9 +184,11 @@ public class MapServiceTest {
         given(schedule.getScheduleName()).willReturn(scheduleName);
         given(arrivalRepository.isAllMembersInScheduleArrived(scheduleId)).willReturn(false);
 
+        // When
         MemberArrivalDto dto = new MemberArrivalDto(now);
         Long res = mapService.makeMemberArrive(memberId, scheduleId, dto);
 
+        // Then
         assertThat(res).isEqualTo(scheduleId);
         then(arrivalRepository).should().save(any(Arrival.class));
         then(scheduleLocationRepository).should().saveLocation(scheduleId, memberId, 1.0, 2.0);
@@ -176,21 +199,26 @@ public class MapServiceTest {
 
     @Test
     void makeMemberArrive_멤버없음_예외() {
+        // Given
         given(scheduleRepository.existMemberInSchedule(memberId, scheduleId)).willReturn(false);
 
+        // When & Then
         assertThrows(ScheduleException.class, () -> mapService.makeMemberArrive(memberId, scheduleId, new MemberArrivalDto(now)));
     }
 
     @Test
     void makeMemberArrive_스케줄상태_예외() {
+        // Given
         given(scheduleRepository.existMemberInSchedule(memberId, scheduleId)).willReturn(true);
         given(scheduleRepository.existsByIdAndScheduleStatusAndStatus(scheduleId, RUN, Status.ALIVE)).willReturn(false);
 
+        // When & Then
         assertThrows(ScheduleException.class, () -> mapService.makeMemberArrive(memberId, scheduleId, new MemberArrivalDto(now)));
     }
 
     @Test
     void sendEmoji_정상() {
+        // Given
         EmojiDto emojiDto = new EmojiDto(2L, EmojiType.HEART);
         AlarmMemberInfo sender = mock(AlarmMemberInfo.class);
         AlarmMemberInfo receiver = mock(AlarmMemberInfo.class);
@@ -203,70 +231,89 @@ public class MapServiceTest {
         given(scheduleRepository.findById(scheduleId)).willReturn(Optional.of(schedule));
         given(schedule.getScheduleName()).willReturn(scheduleName);
 
+        // When
         Long res = mapService.sendEmoji(memberId, scheduleId, emojiDto);
 
+        // Then
         assertThat(res).isEqualTo(scheduleId);
         then(kafkaService).should().sendMessage(eq(KafkaTopic.ALARM), any(EmojiMessage.class));
     }
 
     @Test
     void sendEmoji_멤버없음_예외() {
+        // Given
         EmojiDto emojiDto = new EmojiDto(2L, EmojiType.HEART);
         given(scheduleRepository.existMemberInSchedule(memberId, scheduleId)).willReturn(false);
 
+        // When & Then
         assertThrows(ScheduleException.class, () -> mapService.sendEmoji(memberId, scheduleId, emojiDto));
     }
 
     @Test
     void sendEmoji_스케줄상태_예외() {
+        // Given
         EmojiDto emojiDto = new EmojiDto(2L, EmojiType.HEART);
         given(scheduleRepository.existMemberInSchedule(memberId, scheduleId)).willReturn(true);
         given(scheduleRepository.existsByIdAndScheduleStatusAndStatus(scheduleId, RUN, Status.ALIVE)).willReturn(false);
 
+        // When & Then
         assertThrows(ScheduleException.class, () -> mapService.sendEmoji(memberId, scheduleId, emojiDto));
     }
 
     @Test
     void deleteAllLocationsInSchedule_정상() {
+        // Given
         mapService.deleteAllLocationsInSchedule(scheduleId);
 
+        // When & Then
         then(scheduleLocationRepository).should().deleteScheduleLocations(scheduleId);
     }
 
     @Test
     void makeNotArrivedMemberArrive_정상() {
+        // Given
         ScheduleMember sm1 = mock(ScheduleMember.class);
         ScheduleMember sm2 = mock(ScheduleMember.class);
         List<ScheduleMember> notArrived = List.of(sm1, sm2);
         given(scheduleRepository.findScheduleMembersNotInArrivalByScheduleId(scheduleId)).willReturn(notArrived);
 
+        // When
         mapService.makeNotArrivedMemberArrive(scheduleId, now);
+
+        // Then
         then(arrivalRepository).should().saveAll(anyList());
     }
 
     @Test
     void sendKafkaAlarmIfMemberArrived_정상() {
+        // Given
         List<String> tokens = List.of("token1", "token2");
         AlarmMemberInfo info = mock(AlarmMemberInfo.class);
         given(scheduleRepository.findAllFcmTokensInSchedule(scheduleId)).willReturn(tokens);
         given(memberRepository.findMemberInfo(memberId)).willReturn(Optional.of(info));
 
+        // When
         mapService.sendKafkaAlarmIfMemberArrived(memberId, scheduleId, scheduleName, now);
 
+        // Then
         then(kafkaService).should().sendMessage(eq(KafkaTopic.ALARM), any(ArrivalAlarmMessage.class));
     }
 
     @Test
     void sendKafkaEventIfScheduleClosed_정상() {
+        // Given
         mapService.sendKafkaEventIfScheduleClosed(scheduleId, now);
 
+        // When & Then
         then(kafkaService).should().sendMessage(eq(KafkaTopic.SCHEDULE_CLOSE), any(ScheduleCloseMessage.class));
     }
 
     @Test
     void findSchedule_없으면_예외() {
+        // Given
         given(scheduleRepository.findById(scheduleId)).willReturn(Optional.empty());
 
+        // When & Then
         assertThrows(ScheduleException.class, () -> {
             // private 메서드 테스트를 위해 public 메서드를 호출
             mapService.getScheduleDetail(memberId, scheduleId);
@@ -275,26 +322,32 @@ public class MapServiceTest {
 
     @Test
     void findScheduleMember_없으면_예외() {
+        // Given
         given(scheduleRepository.existMemberInSchedule(memberId, scheduleId)).willReturn(true);
         given(scheduleRepository.existsByIdAndScheduleStatusAndStatus(scheduleId, RUN, Status.ALIVE)).willReturn(true);
         given(scheduleRepository.findById(scheduleId)).willReturn(Optional.of(mock(Schedule.class)));
         given(scheduleRepository.findScheduleMember(memberId, scheduleId)).willReturn(Optional.empty());
 
+        // When & Then
         assertThrows(ScheduleException.class, () -> mapService.makeMemberArrive(memberId, scheduleId, new MemberArrivalDto(now)));
     }
 
     @Test
     void checkMemberInSchedule_없으면_예외() {
+        // Given
         given(scheduleRepository.existMemberInSchedule(memberId, scheduleId)).willReturn(false);
 
+        // When & Then
         assertThrows(ScheduleException.class, () -> mapService.getAllLocation(memberId, scheduleId));
     }
 
     @Test
     void checkScheduleInRun_없으면_예외() {
+        // Given
         given(scheduleRepository.existMemberInSchedule(memberId, scheduleId)).willReturn(true);
         given(scheduleRepository.existsByIdAndScheduleStatusAndStatus(scheduleId, RUN, Status.ALIVE)).willReturn(false);
 
+        // When & Then
         assertThrows(ScheduleException.class, () -> mapService.makeMemberArrive(memberId, scheduleId, new MemberArrivalDto(now)));
     }
 }

--- a/aiku/aiku-map/src/test/java/map/service/map/MapServiceTest.java
+++ b/aiku/aiku-map/src/test/java/map/service/map/MapServiceTest.java
@@ -1,4 +1,4 @@
-package map.service.unit_test;
+package map.service.map;
 
 import common.domain.Arrival;
 import common.domain.Location;
@@ -36,7 +36,7 @@ import static org.mockito.BDDMockito.given;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-public class MapServiceUnitTest {
+public class MapServiceTest {
 
     @Mock KafkaProducerService kafkaService;
     @Mock MemberRepository memberRepository;
@@ -45,7 +45,8 @@ public class MapServiceUnitTest {
     @Mock ArrivalRepository arrivalRepository;
     @Mock ApplicationEventPublisher publisher;
 
-    @InjectMocks MapService mapService;
+    @InjectMocks
+    MapService mapService;
 
     Long memberId = 1L;
     Long scheduleId = 10L;

--- a/aiku/aiku-map/src/test/java/map/service/racing/RacingServiceIntegrationTest.java
+++ b/aiku/aiku-map/src/test/java/map/service/racing/RacingServiceIntegrationTest.java
@@ -1,4 +1,4 @@
-package map.service;
+package map.service.racing;
 
 import common.domain.ExecStatus;
 import common.domain.Location;
@@ -17,6 +17,7 @@ import map.exception.NotEnoughPointException;
 import map.exception.RacingException;
 import map.exception.ScheduleException;
 import map.repository.racing.RacingRepository;
+import map.service.RacingService;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -32,7 +33,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @Transactional
 @SpringBootTest
-class RacingServiceTest {
+class RacingServiceIntegrationTest {
 
     @Autowired
     EntityManager em;

--- a/aiku/aiku-map/src/test/java/map/service/racing/RacingServiceTest.java
+++ b/aiku/aiku-map/src/test/java/map/service/racing/RacingServiceTest.java
@@ -1,4 +1,502 @@
 package map.service.racing;
 
+import common.domain.Status;
+import common.domain.member.MemberProfileBackground;
+import common.domain.member.MemberProfileCharacter;
+import common.domain.member.MemberProfileType;
+import common.domain.racing.Racing;
+import common.domain.schedule.Schedule;
+import common.kafka_message.KafkaTopic;
+import common.kafka_message.PointChangeReason;
+import common.kafka_message.PointChangedMessage;
+import common.kafka_message.PointChangedType;
+import common.kafka_message.alarm.*;
+import map.application_event.domain.RacingInfo;
+import map.application_event.event.AskRacingEvent;
+import map.dto.*;
+import map.exception.NotEnoughPointException;
+import map.exception.RacingException;
+import map.exception.ScheduleException;
+import map.kafka.KafkaProducerService;
+import map.repository.member.MemberRepository;
+import map.repository.racing.RacingRepository;
+import map.repository.schedule.ScheduleRepository;
+import map.service.RacingService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static common.domain.ExecStatus.RUN;
+import static common.domain.ExecStatus.WAIT;
+import static common.response.status.BaseErrorCode.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
 public class RacingServiceTest {
+
+    @Mock private KafkaProducerService kafkaService;
+    @Mock private ApplicationEventPublisher publisher;
+    @Mock private RacingRepository racingRepository;
+    @Mock private ScheduleRepository scheduleRepository;
+    @Mock private MemberRepository memberRepository;
+    @InjectMocks private RacingService racingService;
+
+    @Captor private ArgumentCaptor<AskRacingEvent> askRacingEventCaptor;
+    @Captor private ArgumentCaptor<AskRacingMessage> askRacingMessageCaptor;
+    @Captor private ArgumentCaptor<RacingStartMessage> racingStartMessageCaptor;
+    @Captor private ArgumentCaptor<RacingDeniedMessage> racingDeniedMessageCaptor;
+    @Captor private ArgumentCaptor<RacingTermMessage> racingTermMessageCaptor;
+    @Captor private ArgumentCaptor<PointChangedMessage> pointChangedMessageCaptor;
+    @Captor private ArgumentCaptor<RacingAutoDeletedMessage> racingAutoDeletedMessageCaptor;
+
+    private final Long MEMBER_ID = 1L;
+    private final Long TARGET_MEMBER_ID = 2L;
+    private final Long SCHEDULE_ID = 10L;
+    private final Long RACING_ID = 100L;
+    private final Long SCHEDULE_MEMBER_ID = 20L;
+    private final Long TARGET_SCHEDULE_MEMBER_ID = 21L;
+    private final Integer POINT_AMOUNT = 100;
+    private final String SCHEDULE_NAME = "테스트 스케줄";
+    private final String MEMBER_FCM_TOKEN = "member_fcm_token";
+    private final String TARGET_MEMBER_FCM_TOKEN = "target_member_fcm_token";
+
+    @Test
+    @DisplayName("getRacings: 스케줄의 모든 진행 중인 레이싱 조회")
+    void getRacings_ShouldReturnAllRunningRacings() {
+        // Given
+        given(scheduleRepository.existMemberInSchedule(MEMBER_ID, SCHEDULE_ID)).willReturn(true);
+        given(scheduleRepository.existsByIdAndScheduleStatusAndStatus(SCHEDULE_ID, RUN, Status.ALIVE)).willReturn(true);
+        
+        LocalDateTime now = LocalDateTime.now();
+        MemberProfileDto profile = new MemberProfileDto(MemberProfileType.IMG, "img.png", MemberProfileCharacter.C01, MemberProfileBackground.GREEN);
+        
+        List<RacingResDto> expectedRacings = List.of(
+                new RacingResDto(
+                        new RacerResDto(MEMBER_ID, "사용자1", profile),
+                        new RacerResDto(TARGET_MEMBER_ID, "사용자2", profile),
+                        now
+                )
+        );
+        given(racingRepository.getAllRunningRacingsInSchedule(SCHEDULE_ID)).willReturn(expectedRacings);
+
+        // When
+        DataResDto<List<RacingResDto>> result = racingService.getRacings(MEMBER_ID, SCHEDULE_ID);
+
+        // Then
+        assertThat(result.getData().size()).isEqualTo(1);
+        assertThat(result.getData()).isEqualTo(expectedRacings);
+        then(scheduleRepository).should().existMemberInSchedule(MEMBER_ID, SCHEDULE_ID);
+        then(scheduleRepository).should().existsByIdAndScheduleStatusAndStatus(SCHEDULE_ID, RUN, Status.ALIVE);
+        then(racingRepository).should().getAllRunningRacingsInSchedule(SCHEDULE_ID);
+    }
+
+    @Test
+    @DisplayName("getRacings: 멤버가 스케줄에 속하지 않으면 예외 발생")
+    void getRacings_WhenMemberNotInSchedule_ShouldThrowException() {
+        // Given
+        given(scheduleRepository.existMemberInSchedule(MEMBER_ID, SCHEDULE_ID)).willReturn(false);
+
+        // When & Then
+        ScheduleException exception = assertThrows(ScheduleException.class, 
+            () -> racingService.getRacings(MEMBER_ID, SCHEDULE_ID));
+        assertThat(exception.getStatus()).isEqualTo(NOT_IN_SCHEDULE);
+    }
+
+    @Test
+    @DisplayName("getRacings: 스케줄이 진행 중이 아니면 예외 발생")
+    void getRacings_WhenScheduleNotRunning_ShouldThrowException() {
+        // Given
+        given(scheduleRepository.existMemberInSchedule(MEMBER_ID, SCHEDULE_ID)).willReturn(true);
+        given(scheduleRepository.existsByIdAndScheduleStatusAndStatus(SCHEDULE_ID, RUN, Status.ALIVE)).willReturn(false);
+
+        // When & Then
+        ScheduleException exception = assertThrows(ScheduleException.class, 
+            () -> racingService.getRacings(MEMBER_ID, SCHEDULE_ID));
+        assertThat(exception.getStatus()).isEqualTo(NO_SUCH_SCHEDULE);
+    }
+
+    @Test
+    @DisplayName("makeRacing: 레이싱 생성 성공")
+    void makeRacing_ShouldCreateRacingSuccessfully() {
+        // Given
+        RacingAddDto racingAddDto = new RacingAddDto(TARGET_MEMBER_ID, POINT_AMOUNT);
+        Schedule schedule = mock(Schedule.class);
+        AlarmMemberInfo memberInfo = mock(AlarmMemberInfo.class);
+        
+        given(scheduleRepository.existsByIdAndScheduleStatusAndStatus(SCHEDULE_ID, RUN, Status.ALIVE)).willReturn(true);
+        given(racingRepository.existsByFirstMemberIdAndSecondMemberId(SCHEDULE_ID, MEMBER_ID, TARGET_MEMBER_ID)).willReturn(false);
+        given(memberRepository.checkEnoughRacingPoint(MEMBER_ID, POINT_AMOUNT)).willReturn(true);
+        given(memberRepository.checkEnoughRacingPoint(TARGET_MEMBER_ID, POINT_AMOUNT)).willReturn(true);
+        
+        given(scheduleRepository.findScheduleMemberIdByMemberAndScheduleId(MEMBER_ID, SCHEDULE_ID)).willReturn(Optional.of(SCHEDULE_MEMBER_ID));
+        given(scheduleRepository.findScheduleMemberIdByMemberAndScheduleId(TARGET_MEMBER_ID, SCHEDULE_ID)).willReturn(Optional.of(TARGET_SCHEDULE_MEMBER_ID));
+
+        Racing newRacing = Racing.create(SCHEDULE_MEMBER_ID, TARGET_SCHEDULE_MEMBER_ID, POINT_AMOUNT);
+        given(racingRepository.save(any(Racing.class))).willReturn(newRacing);
+        
+        given(scheduleRepository.findById(SCHEDULE_ID)).willReturn(Optional.of(schedule));
+        given(schedule.getScheduleName()).willReturn(SCHEDULE_NAME);
+        given(memberRepository.findMemberInfo(MEMBER_ID)).willReturn(Optional.of(memberInfo));
+        given(memberRepository.findMemberFirebaseTokenById(TARGET_MEMBER_ID)).willReturn(Optional.of(TARGET_MEMBER_FCM_TOKEN));
+
+        // When
+        racingService.makeRacing(MEMBER_ID, SCHEDULE_ID, racingAddDto);
+
+        // Then
+        then(racingRepository).should().save(any(Racing.class));
+        
+        // AskRacingMessage 검증
+        then(kafkaService).should().sendMessage(eq(KafkaTopic.ALARM), askRacingMessageCaptor.capture());
+        AskRacingMessage capturedAskRacingMessage = askRacingMessageCaptor.getValue();
+        assertThat(capturedAskRacingMessage.getAlarmReceiverTokens()).isEqualTo(List.of(TARGET_MEMBER_FCM_TOKEN));
+        assertThat(capturedAskRacingMessage.getAlarmMessageType()).isEqualTo(AlarmMessageType.ASK_RACING);
+        assertThat(capturedAskRacingMessage.getScheduleId()).isEqualTo(SCHEDULE_ID);
+        assertThat(capturedAskRacingMessage.getScheduleName()).isEqualTo(SCHEDULE_NAME);
+        assertThat(capturedAskRacingMessage.getPoint()).isEqualTo(POINT_AMOUNT);
+        assertThat(capturedAskRacingMessage.getFirstRacerInfo()).isEqualTo(memberInfo);
+        
+        // AskRacingEvent 검증
+        then(publisher).should().publishEvent(askRacingEventCaptor.capture());
+        AskRacingEvent capturedAskRacingEvent = askRacingEventCaptor.getValue();
+        assertThat(capturedAskRacingEvent.getRacingInfo().getScheduleId()).isEqualTo(SCHEDULE_ID);
+        assertThat(capturedAskRacingEvent.getRacingInfo().getScheduleName()).isEqualTo(SCHEDULE_NAME);
+        assertThat(capturedAskRacingEvent.getRacingInfo().getFirstRacerId()).isEqualTo(MEMBER_ID);
+        assertThat(capturedAskRacingEvent.getRacingInfo().getSecondRacerId()).isEqualTo(TARGET_MEMBER_ID);
+        assertThat(capturedAskRacingEvent.getRacingInfo().getPointAmount()).isEqualTo(POINT_AMOUNT);
+    }
+
+    @Test
+    @DisplayName("makeRacing: 스케줄이 진행 중이 아니면 예외 발생")
+    void makeRacing_WhenScheduleNotRunning_ShouldThrowException() {
+        // Given
+        RacingAddDto racingAddDto = new RacingAddDto(TARGET_MEMBER_ID, POINT_AMOUNT);
+        given(scheduleRepository.existsByIdAndScheduleStatusAndStatus(SCHEDULE_ID, RUN, Status.ALIVE)).willReturn(false);
+
+        // When & Then
+        ScheduleException exception = assertThrows(ScheduleException.class, 
+            () -> racingService.makeRacing(MEMBER_ID, SCHEDULE_ID, racingAddDto));
+        assertThat(exception.getStatus()).isEqualTo(NO_SUCH_SCHEDULE);
+    }
+
+    @Test
+    @DisplayName("makeRacing: 중복된 레이싱이 있으면 예외 발생")
+    void makeRacing_WhenDuplicateRacingExists_ShouldThrowException() {
+        // Given
+        RacingAddDto racingAddDto = new RacingAddDto(TARGET_MEMBER_ID, POINT_AMOUNT);
+        given(scheduleRepository.existsByIdAndScheduleStatusAndStatus(SCHEDULE_ID, RUN, Status.ALIVE)).willReturn(true);
+        given(racingRepository.existsByFirstMemberIdAndSecondMemberId(SCHEDULE_ID, MEMBER_ID, TARGET_MEMBER_ID)).willReturn(true);
+
+        // When & Then
+        RacingException exception = assertThrows(RacingException.class, 
+            () -> racingService.makeRacing(MEMBER_ID, SCHEDULE_ID, racingAddDto));
+        assertThat(exception.getStatus()).isEqualTo(DUPLICATE_RACING);
+    }
+
+    @Test
+    @DisplayName("makeRacing: 사용자의 포인트가 부족하면 예외 발생")
+    void makeRacing_WhenNotEnoughPoints_ShouldThrowException() {
+        // Given
+        RacingAddDto racingAddDto = new RacingAddDto(TARGET_MEMBER_ID, POINT_AMOUNT);
+        given(scheduleRepository.existsByIdAndScheduleStatusAndStatus(SCHEDULE_ID, RUN, Status.ALIVE)).willReturn(true);
+        given(racingRepository.existsByFirstMemberIdAndSecondMemberId(SCHEDULE_ID, MEMBER_ID, TARGET_MEMBER_ID)).willReturn(false);
+        given(memberRepository.checkEnoughRacingPoint(MEMBER_ID, POINT_AMOUNT)).willReturn(false);
+
+        // When & Then
+        assertThrows(NotEnoughPointException.class, 
+            () -> racingService.makeRacing(MEMBER_ID, SCHEDULE_ID, racingAddDto));
+    }
+
+    @Test
+    @DisplayName("makeRacing: 대상 사용자의 포인트가 부족하면 예외 발생")
+    void makeRacing_WhenTargetNotEnoughPoints_ShouldThrowException() {
+        // Given
+        RacingAddDto racingAddDto = new RacingAddDto(TARGET_MEMBER_ID, POINT_AMOUNT);
+        given(scheduleRepository.existsByIdAndScheduleStatusAndStatus(SCHEDULE_ID, RUN, Status.ALIVE)).willReturn(true);
+        given(racingRepository.existsByFirstMemberIdAndSecondMemberId(SCHEDULE_ID, MEMBER_ID, TARGET_MEMBER_ID)).willReturn(false);
+        given(memberRepository.checkEnoughRacingPoint(MEMBER_ID, POINT_AMOUNT)).willReturn(true);
+        given(memberRepository.checkEnoughRacingPoint(TARGET_MEMBER_ID, POINT_AMOUNT)).willReturn(false);
+
+        // When & Then
+        assertThrows(NotEnoughPointException.class, 
+            () -> racingService.makeRacing(MEMBER_ID, SCHEDULE_ID, racingAddDto));
+    }
+
+    @Test
+    @DisplayName("autoDeleteRacingById: 자동 레이싱 삭제 성공")
+    void autoDeleteRacingById_ShouldDeleteRacing() {
+        // Given
+        RacingInfo racingInfo = new RacingInfo(SCHEDULE_ID, SCHEDULE_NAME, RACING_ID, MEMBER_ID, TARGET_MEMBER_ID, POINT_AMOUNT);
+        AlarmMemberInfo targetMemberInfo = mock(AlarmMemberInfo.class);
+        
+        given(memberRepository.findMemberInfo(TARGET_MEMBER_ID)).willReturn(Optional.of(targetMemberInfo));
+        given(memberRepository.findMemberFirebaseTokenById(MEMBER_ID)).willReturn(Optional.of(MEMBER_FCM_TOKEN));
+        given(memberRepository.findMemberFirebaseTokenById(TARGET_MEMBER_ID)).willReturn(Optional.of(TARGET_MEMBER_FCM_TOKEN));
+
+        // When
+        racingService.autoDeleteRacingById(racingInfo);
+
+        // Then
+        then(racingRepository).should().deleteById(RACING_ID);
+        
+        // RacingAutoDeletedMessage 검증
+        then(kafkaService).should().sendMessage(eq(KafkaTopic.ALARM), racingAutoDeletedMessageCaptor.capture());
+        RacingAutoDeletedMessage capturedMessage = racingAutoDeletedMessageCaptor.getValue();
+        assertThat(capturedMessage.getAlarmReceiverTokens()).isEqualTo(List.of(MEMBER_FCM_TOKEN, TARGET_MEMBER_FCM_TOKEN));
+        assertThat(capturedMessage.getAlarmMessageType()).isEqualTo(AlarmMessageType.RACING_AUTO_DELETED);
+        assertThat(capturedMessage.getScheduleId()).isEqualTo(SCHEDULE_ID);
+        assertThat(capturedMessage.getScheduleName()).isEqualTo(SCHEDULE_NAME);
+        assertThat(capturedMessage.getRacingId()).isEqualTo(RACING_ID);
+        assertThat(capturedMessage.getPoint()).isEqualTo(POINT_AMOUNT);
+        assertThat(capturedMessage.getSecondRacerInfo()).isEqualTo(targetMemberInfo);
+    }
+
+    @Test
+    @DisplayName("acceptRacing: 레이싱 수락 성공")
+    void acceptRacing_ShouldAcceptRacing() {
+        // Given
+        Racing racing = mock(Racing.class);
+        Schedule schedule = mock(Schedule.class);
+        AlarmMemberInfo memberInfo = mock(AlarmMemberInfo.class);
+        AlarmMemberInfo targetMemberInfo = mock(AlarmMemberInfo.class);
+        
+        given(racing.getPointAmount()).willReturn(POINT_AMOUNT);
+        given(schedule.getScheduleName()).willReturn(SCHEDULE_NAME);
+        
+        given(racingRepository.existsByIdAndRaceStatusAndStatus(RACING_ID, WAIT, Status.ALIVE)).willReturn(true);
+        given(racingRepository.checkBothMemberHaveEnoughRacingPoint(RACING_ID)).willReturn(true);
+        given(racingRepository.findById(RACING_ID)).willReturn(Optional.of(racing));
+        
+        List<AlarmMemberInfo> memberInfos = Arrays.asList(memberInfo, targetMemberInfo);
+        given(racingRepository.findMemberInfoByScheduleMemberId(RACING_ID)).willReturn(memberInfos);
+        given(racingRepository.findRacersFcmTokensInRacing(RACING_ID)).willReturn(Arrays.asList(MEMBER_FCM_TOKEN, TARGET_MEMBER_FCM_TOKEN));
+        given(scheduleRepository.findById(SCHEDULE_ID)).willReturn(Optional.of(schedule));
+
+        // When
+        Long result = racingService.acceptRacing(MEMBER_ID, SCHEDULE_ID, RACING_ID);
+
+        // Then
+        assertThat(result).isEqualTo(RACING_ID);
+        then(racing).should().startRacing();
+        
+        // RacingStartMessage 검증
+        then(kafkaService).should().sendMessage(eq(KafkaTopic.ALARM), racingStartMessageCaptor.capture());
+        RacingStartMessage capturedStartMessage = racingStartMessageCaptor.getValue();
+        assertThat(capturedStartMessage.getAlarmReceiverTokens()).isEqualTo(List.of(MEMBER_FCM_TOKEN, TARGET_MEMBER_FCM_TOKEN));
+        assertThat(capturedStartMessage.getAlarmMessageType()).isEqualTo(AlarmMessageType.RACING_START);
+        assertThat(capturedStartMessage.getScheduleId()).isEqualTo(SCHEDULE_ID);
+        assertThat(capturedStartMessage.getScheduleName()).isEqualTo(SCHEDULE_NAME);
+        assertThat(capturedStartMessage.getRacingId()).isEqualTo(RACING_ID);
+        assertThat(capturedStartMessage.getPoint()).isEqualTo(POINT_AMOUNT);
+        assertThat(capturedStartMessage.getFirstRacerInfo()).isEqualTo(memberInfo);
+        assertThat(capturedStartMessage.getSecondRacerInfo()).isEqualTo(targetMemberInfo);
+        
+        // PointChangedMessage 검증 (2개 메시지)
+        then(kafkaService).should(times(2)).sendMessage(eq(KafkaTopic.ALARM), pointChangedMessageCaptor.capture());
+        List<PointChangedMessage> pointChangedMessages = pointChangedMessageCaptor.getAllValues();
+        
+        // 첫 번째 메시지 검증
+        assertThat(pointChangedMessages.get(0).getMemberId()).isEqualTo(memberInfos.get(0).getMemberId());
+        assertThat(pointChangedMessages.get(0).getPointChangedType()).isEqualTo(PointChangedType.MINUS);
+        assertThat(pointChangedMessages.get(0).getPointAmount()).isEqualTo(POINT_AMOUNT);
+        assertThat(pointChangedMessages.get(0).getReason()).isEqualTo(PointChangeReason.RACING);
+        assertThat(pointChangedMessages.get(0).getReasonId()).isEqualTo(RACING_ID);
+        
+        // 두 번째 메시지 검증
+        assertThat(pointChangedMessages.get(1).getMemberId()).isEqualTo(memberInfos.get(1).getMemberId());
+        assertThat(pointChangedMessages.get(1).getPointChangedType()).isEqualTo(PointChangedType.MINUS);
+        assertThat(pointChangedMessages.get(1).getPointAmount()).isEqualTo(POINT_AMOUNT);
+        assertThat(pointChangedMessages.get(1).getReason()).isEqualTo(PointChangeReason.RACING);
+        assertThat(pointChangedMessages.get(1).getReasonId()).isEqualTo(RACING_ID);
+    }
+
+    @Test
+    @DisplayName("acceptRacing: 레이싱이 대기 중이 아니면 예외 발생")
+    void acceptRacing_WhenRacingNotWaiting_ShouldThrowException() {
+        // Given
+        given(racingRepository.existsByIdAndRaceStatusAndStatus(RACING_ID, WAIT, Status.ALIVE)).willReturn(false);
+
+        // When & Then
+        ScheduleException exception = assertThrows(ScheduleException.class, 
+            () -> racingService.acceptRacing(MEMBER_ID, SCHEDULE_ID, RACING_ID));
+        assertThat(exception.getStatus()).isEqualTo(NO_SUCH_SCHEDULE);
+    }
+
+    @Test
+    @DisplayName("acceptRacing: 사용자들의 포인트가 부족하면 예외 발생")
+    void acceptRacing_WhenNotEnoughPoints_ShouldThrowException() {
+        // Given
+        given(racingRepository.existsByIdAndRaceStatusAndStatus(RACING_ID, WAIT, Status.ALIVE)).willReturn(true);
+        given(racingRepository.checkBothMemberHaveEnoughRacingPoint(RACING_ID)).willReturn(false);
+
+        // When & Then
+        assertThrows(NotEnoughPointException.class, 
+            () -> racingService.acceptRacing(MEMBER_ID, SCHEDULE_ID, RACING_ID));
+    }
+
+    @Test
+    @DisplayName("denyRacing: 레이싱 거절 성공")
+    void denyRacing_ShouldDenyRacing() {
+        // Given
+        Schedule schedule = mock(Schedule.class);
+        AlarmMemberInfo memberInfo = mock(AlarmMemberInfo.class);
+        
+        given(schedule.getScheduleName()).willReturn(SCHEDULE_NAME);
+        given(racingRepository.existsByIdAndRaceStatusAndStatus(RACING_ID, WAIT, Status.ALIVE)).willReturn(true);
+        given(racingRepository.checkMemberIsSecondRacerInRacing(MEMBER_ID, RACING_ID)).willReturn(true);
+        given(scheduleRepository.findById(SCHEDULE_ID)).willReturn(Optional.of(schedule));
+        given(racingRepository.findRacersFcmTokensInRacing(RACING_ID)).willReturn(Arrays.asList(MEMBER_FCM_TOKEN, TARGET_MEMBER_FCM_TOKEN));
+        given(memberRepository.findMemberInfo(MEMBER_ID)).willReturn(Optional.of(memberInfo));
+
+        // When
+        Long result = racingService.denyRacing(MEMBER_ID, SCHEDULE_ID, RACING_ID);
+
+        // Then
+        assertThat(result).isEqualTo(RACING_ID);
+        then(racingRepository).should().cancelRacing(RACING_ID);
+        
+        // RacingDeniedMessage 검증
+        then(kafkaService).should().sendMessage(eq(KafkaTopic.ALARM), racingDeniedMessageCaptor.capture());
+        RacingDeniedMessage capturedDeniedMessage = racingDeniedMessageCaptor.getValue();
+        assertThat(capturedDeniedMessage.getAlarmReceiverTokens()).isEqualTo(List.of(MEMBER_FCM_TOKEN, TARGET_MEMBER_FCM_TOKEN));
+        assertThat(capturedDeniedMessage.getAlarmMessageType()).isEqualTo(AlarmMessageType.RACING_DENIED);
+        assertThat(capturedDeniedMessage.getScheduleId()).isEqualTo(SCHEDULE_ID);
+        assertThat(capturedDeniedMessage.getScheduleName()).isEqualTo(SCHEDULE_NAME);
+        assertThat(capturedDeniedMessage.getRacingId()).isEqualTo(RACING_ID);
+        assertThat(capturedDeniedMessage.getSecondRacerInfo()).isEqualTo(memberInfo);
+    }
+
+    @Test
+    @DisplayName("denyRacing: 레이싱이 대기 중이 아니면 예외 발생")
+    void denyRacing_WhenRacingNotWaiting_ShouldThrowException() {
+        // Given
+        given(racingRepository.existsByIdAndRaceStatusAndStatus(RACING_ID, WAIT, Status.ALIVE)).willReturn(false);
+
+        // When & Then
+        ScheduleException exception = assertThrows(ScheduleException.class, 
+            () -> racingService.denyRacing(MEMBER_ID, SCHEDULE_ID, RACING_ID));
+        assertThat(exception.getStatus()).isEqualTo(NO_SUCH_SCHEDULE);
+    }
+
+    @Test
+    @DisplayName("denyRacing: 사용자가 두 번째 레이서가 아니면 예외 발생")
+    void denyRacing_WhenMemberIsNotSecondRacer_ShouldThrowException() {
+        // Given
+        given(racingRepository.existsByIdAndRaceStatusAndStatus(RACING_ID, WAIT, Status.ALIVE)).willReturn(true);
+        given(racingRepository.checkMemberIsSecondRacerInRacing(MEMBER_ID, RACING_ID)).willReturn(false);
+
+        // When & Then
+        RacingException exception = assertThrows(RacingException.class, 
+            () -> racingService.denyRacing(MEMBER_ID, SCHEDULE_ID, RACING_ID));
+        assertThat(exception.getStatus()).isEqualTo(NOT_IN_RACING);
+    }
+
+    @Test
+    @DisplayName("makeMemberWinnerInRacing: 사용자를 레이싱 우승자로 설정 성공")
+    void makeMemberWinnerInRacing_ShouldMakeMemberWinner() {
+        // Given
+        AlarmMemberInfo memberInfo = mock(AlarmMemberInfo.class);
+        AlarmMemberInfo targetMemberInfo = mock(AlarmMemberInfo.class);
+        
+        given(scheduleRepository.findScheduleMemberIdByMemberAndScheduleId(MEMBER_ID, SCHEDULE_ID))
+            .willReturn(Optional.of(SCHEDULE_MEMBER_ID));
+        
+        RunningRacingDto racingDto = new RunningRacingDto(
+            RACING_ID, SCHEDULE_MEMBER_ID, TARGET_SCHEDULE_MEMBER_ID, POINT_AMOUNT
+        );
+        given(racingRepository.findRunningRacingsByScheduleMemberId(SCHEDULE_MEMBER_ID))
+            .willReturn(Collections.singletonList(racingDto));
+        
+        given(memberRepository.findMemberInfoByScheduleMemberId(SCHEDULE_MEMBER_ID))
+            .willReturn(Optional.of(memberInfo));
+        given(memberRepository.findMemberInfoByScheduleMemberId(TARGET_SCHEDULE_MEMBER_ID))
+            .willReturn(Optional.of(targetMemberInfo));
+        
+        given(racingRepository.findRacersFcmTokensInRacing(RACING_ID))
+            .willReturn(Arrays.asList(MEMBER_FCM_TOKEN, TARGET_MEMBER_FCM_TOKEN));
+        
+        // When
+        racingService.makeMemberWinnerInRacing(MEMBER_ID, SCHEDULE_ID, SCHEDULE_NAME);
+        
+        // Then
+        then(racingRepository).should().setWinnerAndTermRacingByScheduleMemberId(SCHEDULE_MEMBER_ID);
+        
+        // PointChangedMessage 검증
+        then(kafkaService).should().sendMessage(eq(KafkaTopic.ALARM), pointChangedMessageCaptor.capture());
+        PointChangedMessage capturedPointMessage = pointChangedMessageCaptor.getValue();
+        assertThat(capturedPointMessage.getMemberId()).isEqualTo(memberInfo.getMemberId());
+        assertThat(capturedPointMessage.getPointChangedType()).isEqualTo(PointChangedType.PLUS);
+        assertThat(capturedPointMessage.getPointAmount()).isEqualTo(POINT_AMOUNT * 2);
+        assertThat(capturedPointMessage.getReason()).isEqualTo(PointChangeReason.RACING_REWARD);
+        assertThat(capturedPointMessage.getReasonId()).isEqualTo(RACING_ID);
+        
+        // RacingTermMessage 검증
+        then(kafkaService).should().sendMessage(eq(KafkaTopic.ALARM), racingTermMessageCaptor.capture());
+        RacingTermMessage capturedTermMessage = racingTermMessageCaptor.getValue();
+        assertThat(capturedTermMessage.getAlarmReceiverTokens()).isEqualTo(List.of(MEMBER_FCM_TOKEN, TARGET_MEMBER_FCM_TOKEN));
+        assertThat(capturedTermMessage.getAlarmMessageType()).isEqualTo(AlarmMessageType.RACING_TERM);
+        assertThat(capturedTermMessage.getScheduleId()).isEqualTo(SCHEDULE_ID);
+        assertThat(capturedTermMessage.getScheduleName()).isEqualTo(SCHEDULE_NAME);
+        assertThat(capturedTermMessage.getRacingId()).isEqualTo(RACING_ID);
+        assertThat(capturedTermMessage.getPoint()).isEqualTo(POINT_AMOUNT);
+        assertThat(capturedTermMessage.getWinnerRacerInfo()).isEqualTo(memberInfo);
+        assertThat(capturedTermMessage.getLoserRacerInfo()).isEqualTo(targetMemberInfo);
+    }
+
+    @Test
+    @DisplayName("terminateRunningRacing: 모든 진행 중인 레이싱 종료 처리")
+    void terminateRunningRacing_ShouldTerminateAllRunningRacings() {
+        // Given
+        AlarmMemberInfo memberInfo = mock(AlarmMemberInfo.class);
+        AlarmMemberInfo targetMemberInfo = mock(AlarmMemberInfo.class);
+        
+        TermRacingDto racingDto = new TermRacingDto(
+            RACING_ID, SCHEDULE_MEMBER_ID, TARGET_SCHEDULE_MEMBER_ID, POINT_AMOUNT
+        );
+        given(racingRepository.findTermRacingIdsWithNoWinnerInSchedule(SCHEDULE_ID))
+            .willReturn(Collections.singletonList(racingDto));
+        
+        given(memberRepository.findMemberInfoByScheduleMemberId(SCHEDULE_MEMBER_ID))
+            .willReturn(Optional.of(memberInfo));
+        given(memberRepository.findMemberInfoByScheduleMemberId(TARGET_SCHEDULE_MEMBER_ID))
+            .willReturn(Optional.of(targetMemberInfo));
+        
+        // When
+        racingService.terminateRunningRacing(SCHEDULE_ID);
+        
+        // Then
+        then(racingRepository).should().terminateRunningRacing(SCHEDULE_ID);
+        
+        // PointChangedMessage 검증 (2개 메시지)
+        then(kafkaService).should(times(2)).sendMessage(eq(KafkaTopic.ALARM), pointChangedMessageCaptor.capture());
+        List<PointChangedMessage> pointChangedMessages = pointChangedMessageCaptor.getAllValues();
+        
+        // 첫 번째 메시지 검증
+        assertThat(pointChangedMessages.get(0).getMemberId()).isEqualTo(memberInfo.getMemberId());
+        assertThat(pointChangedMessages.get(0).getPointChangedType()).isEqualTo(PointChangedType.PLUS);
+        assertThat(pointChangedMessages.get(0).getPointAmount()).isEqualTo(POINT_AMOUNT);
+        assertThat(pointChangedMessages.get(0).getReason()).isEqualTo(PointChangeReason.RACING_DRAW);
+        assertThat(pointChangedMessages.get(0).getReasonId()).isEqualTo(RACING_ID);
+        
+        // 두 번째 메시지 검증
+        assertThat(pointChangedMessages.get(1).getMemberId()).isEqualTo(targetMemberInfo.getMemberId());
+        assertThat(pointChangedMessages.get(1).getPointChangedType()).isEqualTo(PointChangedType.PLUS);
+        assertThat(pointChangedMessages.get(1).getPointAmount()).isEqualTo(POINT_AMOUNT);
+        assertThat(pointChangedMessages.get(1).getReason()).isEqualTo(PointChangeReason.RACING_DRAW);
+        assertThat(pointChangedMessages.get(1).getReasonId()).isEqualTo(RACING_ID);
+    }
 }

--- a/aiku/aiku-map/src/test/java/map/service/racing/RacingServiceTest.java
+++ b/aiku/aiku-map/src/test/java/map/service/racing/RacingServiceTest.java
@@ -76,8 +76,7 @@ public class RacingServiceTest {
     private final String TARGET_MEMBER_FCM_TOKEN = "target_member_fcm_token";
 
     @Test
-    @DisplayName("getRacings: 스케줄의 모든 진행 중인 레이싱 조회")
-    void getRacings_ShouldReturnAllRunningRacings() {
+    void getRacings_정상() {
         // Given
         given(scheduleRepository.existMemberInSchedule(MEMBER_ID, SCHEDULE_ID)).willReturn(true);
         given(scheduleRepository.existsByIdAndScheduleStatusAndStatus(SCHEDULE_ID, RUN, Status.ALIVE)).willReturn(true);
@@ -106,8 +105,7 @@ public class RacingServiceTest {
     }
 
     @Test
-    @DisplayName("getRacings: 멤버가 스케줄에 속하지 않으면 예외 발생")
-    void getRacings_WhenMemberNotInSchedule_ShouldThrowException() {
+    void getRacings_멤버가스케줄에없음_예외() {
         // Given
         given(scheduleRepository.existMemberInSchedule(MEMBER_ID, SCHEDULE_ID)).willReturn(false);
 
@@ -118,8 +116,7 @@ public class RacingServiceTest {
     }
 
     @Test
-    @DisplayName("getRacings: 스케줄이 진행 중이 아니면 예외 발생")
-    void getRacings_WhenScheduleNotRunning_ShouldThrowException() {
+    void getRacings_스케줄이진행중이아님_예외() {
         // Given
         given(scheduleRepository.existMemberInSchedule(MEMBER_ID, SCHEDULE_ID)).willReturn(true);
         given(scheduleRepository.existsByIdAndScheduleStatusAndStatus(SCHEDULE_ID, RUN, Status.ALIVE)).willReturn(false);
@@ -131,8 +128,7 @@ public class RacingServiceTest {
     }
 
     @Test
-    @DisplayName("makeRacing: 레이싱 생성 성공")
-    void makeRacing_ShouldCreateRacingSuccessfully() {
+    void makeRacing_정상() {
         // Given
         RacingAddDto racingAddDto = new RacingAddDto(TARGET_MEMBER_ID, POINT_AMOUNT);
         Schedule schedule = mock(Schedule.class);
@@ -181,8 +177,7 @@ public class RacingServiceTest {
     }
 
     @Test
-    @DisplayName("makeRacing: 스케줄이 진행 중이 아니면 예외 발생")
-    void makeRacing_WhenScheduleNotRunning_ShouldThrowException() {
+    void makeRacing_스케줄이진행중이아님_예외() {
         // Given
         RacingAddDto racingAddDto = new RacingAddDto(TARGET_MEMBER_ID, POINT_AMOUNT);
         given(scheduleRepository.existsByIdAndScheduleStatusAndStatus(SCHEDULE_ID, RUN, Status.ALIVE)).willReturn(false);
@@ -194,8 +189,7 @@ public class RacingServiceTest {
     }
 
     @Test
-    @DisplayName("makeRacing: 중복된 레이싱이 있으면 예외 발생")
-    void makeRacing_WhenDuplicateRacingExists_ShouldThrowException() {
+    void makeRacing_중복레이싱존재_예외() {
         // Given
         RacingAddDto racingAddDto = new RacingAddDto(TARGET_MEMBER_ID, POINT_AMOUNT);
         given(scheduleRepository.existsByIdAndScheduleStatusAndStatus(SCHEDULE_ID, RUN, Status.ALIVE)).willReturn(true);
@@ -208,8 +202,7 @@ public class RacingServiceTest {
     }
 
     @Test
-    @DisplayName("makeRacing: 사용자의 포인트가 부족하면 예외 발생")
-    void makeRacing_WhenNotEnoughPoints_ShouldThrowException() {
+    void makeRacing_사용자포인트부족_예외() {
         // Given
         RacingAddDto racingAddDto = new RacingAddDto(TARGET_MEMBER_ID, POINT_AMOUNT);
         given(scheduleRepository.existsByIdAndScheduleStatusAndStatus(SCHEDULE_ID, RUN, Status.ALIVE)).willReturn(true);
@@ -222,8 +215,7 @@ public class RacingServiceTest {
     }
 
     @Test
-    @DisplayName("makeRacing: 대상 사용자의 포인트가 부족하면 예외 발생")
-    void makeRacing_WhenTargetNotEnoughPoints_ShouldThrowException() {
+    void makeRacing_대상사용자포인트부족_예외() {
         // Given
         RacingAddDto racingAddDto = new RacingAddDto(TARGET_MEMBER_ID, POINT_AMOUNT);
         given(scheduleRepository.existsByIdAndScheduleStatusAndStatus(SCHEDULE_ID, RUN, Status.ALIVE)).willReturn(true);
@@ -237,8 +229,7 @@ public class RacingServiceTest {
     }
 
     @Test
-    @DisplayName("autoDeleteRacingById: 자동 레이싱 삭제 성공")
-    void autoDeleteRacingById_ShouldDeleteRacing() {
+    void autoDeleteRacingById_정상() {
         // Given
         RacingInfo racingInfo = new RacingInfo(SCHEDULE_ID, SCHEDULE_NAME, RACING_ID, MEMBER_ID, TARGET_MEMBER_ID, POINT_AMOUNT);
         AlarmMemberInfo targetMemberInfo = mock(AlarmMemberInfo.class);
@@ -252,7 +243,7 @@ public class RacingServiceTest {
 
         // Then
         then(racingRepository).should().deleteById(RACING_ID);
-        
+
         // RacingAutoDeletedMessage 검증
         then(kafkaService).should().sendMessage(eq(KafkaTopic.ALARM), racingAutoDeletedMessageCaptor.capture());
         RacingAutoDeletedMessage capturedMessage = racingAutoDeletedMessageCaptor.getValue();
@@ -266,21 +257,20 @@ public class RacingServiceTest {
     }
 
     @Test
-    @DisplayName("acceptRacing: 레이싱 수락 성공")
-    void acceptRacing_ShouldAcceptRacing() {
+    void acceptRacing_정상() {
         // Given
         Racing racing = mock(Racing.class);
         Schedule schedule = mock(Schedule.class);
         AlarmMemberInfo memberInfo = mock(AlarmMemberInfo.class);
         AlarmMemberInfo targetMemberInfo = mock(AlarmMemberInfo.class);
-        
+
         given(racing.getPointAmount()).willReturn(POINT_AMOUNT);
         given(schedule.getScheduleName()).willReturn(SCHEDULE_NAME);
-        
+
         given(racingRepository.existsByIdAndRaceStatusAndStatus(RACING_ID, WAIT, Status.ALIVE)).willReturn(true);
         given(racingRepository.checkBothMemberHaveEnoughRacingPoint(RACING_ID)).willReturn(true);
         given(racingRepository.findById(RACING_ID)).willReturn(Optional.of(racing));
-        
+
         List<AlarmMemberInfo> memberInfos = Arrays.asList(memberInfo, targetMemberInfo);
         given(racingRepository.findMemberInfoByScheduleMemberId(RACING_ID)).willReturn(memberInfos);
         given(racingRepository.findRacersFcmTokensInRacing(RACING_ID)).willReturn(Arrays.asList(MEMBER_FCM_TOKEN, TARGET_MEMBER_FCM_TOKEN));
@@ -292,7 +282,7 @@ public class RacingServiceTest {
         // Then
         assertThat(result).isEqualTo(RACING_ID);
         then(racing).should().startRacing();
-        
+
         // RacingStartMessage 검증
         then(kafkaService).should().sendMessage(eq(KafkaTopic.ALARM), racingStartMessageCaptor.capture());
         RacingStartMessage capturedStartMessage = racingStartMessageCaptor.getValue();
@@ -304,18 +294,18 @@ public class RacingServiceTest {
         assertThat(capturedStartMessage.getPoint()).isEqualTo(POINT_AMOUNT);
         assertThat(capturedStartMessage.getFirstRacerInfo()).isEqualTo(memberInfo);
         assertThat(capturedStartMessage.getSecondRacerInfo()).isEqualTo(targetMemberInfo);
-        
+
         // PointChangedMessage 검증 (2개 메시지)
         then(kafkaService).should(times(2)).sendMessage(eq(KafkaTopic.ALARM), pointChangedMessageCaptor.capture());
         List<PointChangedMessage> pointChangedMessages = pointChangedMessageCaptor.getAllValues();
-        
+
         // 첫 번째 메시지 검증
         assertThat(pointChangedMessages.get(0).getMemberId()).isEqualTo(memberInfos.get(0).getMemberId());
         assertThat(pointChangedMessages.get(0).getPointChangedType()).isEqualTo(PointChangedType.MINUS);
         assertThat(pointChangedMessages.get(0).getPointAmount()).isEqualTo(POINT_AMOUNT);
         assertThat(pointChangedMessages.get(0).getReason()).isEqualTo(PointChangeReason.RACING);
         assertThat(pointChangedMessages.get(0).getReasonId()).isEqualTo(RACING_ID);
-        
+
         // 두 번째 메시지 검증
         assertThat(pointChangedMessages.get(1).getMemberId()).isEqualTo(memberInfos.get(1).getMemberId());
         assertThat(pointChangedMessages.get(1).getPointChangedType()).isEqualTo(PointChangedType.MINUS);
@@ -325,36 +315,33 @@ public class RacingServiceTest {
     }
 
     @Test
-    @DisplayName("acceptRacing: 레이싱이 대기 중이 아니면 예외 발생")
-    void acceptRacing_WhenRacingNotWaiting_ShouldThrowException() {
+    void acceptRacing_레이싱이대기중이아님_예외() {
         // Given
         given(racingRepository.existsByIdAndRaceStatusAndStatus(RACING_ID, WAIT, Status.ALIVE)).willReturn(false);
 
         // When & Then
-        ScheduleException exception = assertThrows(ScheduleException.class, 
+        ScheduleException exception = assertThrows(ScheduleException.class,
             () -> racingService.acceptRacing(MEMBER_ID, SCHEDULE_ID, RACING_ID));
         assertThat(exception.getStatus()).isEqualTo(NO_SUCH_SCHEDULE);
     }
 
     @Test
-    @DisplayName("acceptRacing: 사용자들의 포인트가 부족하면 예외 발생")
-    void acceptRacing_WhenNotEnoughPoints_ShouldThrowException() {
+    void acceptRacing_사용자포인트부족_예외() {
         // Given
         given(racingRepository.existsByIdAndRaceStatusAndStatus(RACING_ID, WAIT, Status.ALIVE)).willReturn(true);
         given(racingRepository.checkBothMemberHaveEnoughRacingPoint(RACING_ID)).willReturn(false);
 
         // When & Then
-        assertThrows(NotEnoughPointException.class, 
+        assertThrows(NotEnoughPointException.class,
             () -> racingService.acceptRacing(MEMBER_ID, SCHEDULE_ID, RACING_ID));
     }
 
     @Test
-    @DisplayName("denyRacing: 레이싱 거절 성공")
-    void denyRacing_ShouldDenyRacing() {
+    void denyRacing_정상() {
         // Given
         Schedule schedule = mock(Schedule.class);
         AlarmMemberInfo memberInfo = mock(AlarmMemberInfo.class);
-        
+
         given(schedule.getScheduleName()).willReturn(SCHEDULE_NAME);
         given(racingRepository.existsByIdAndRaceStatusAndStatus(RACING_ID, WAIT, Status.ALIVE)).willReturn(true);
         given(racingRepository.checkMemberIsSecondRacerInRacing(MEMBER_ID, RACING_ID)).willReturn(true);
@@ -368,7 +355,7 @@ public class RacingServiceTest {
         // Then
         assertThat(result).isEqualTo(RACING_ID);
         then(racingRepository).should().cancelRacing(RACING_ID);
-        
+
         // RacingDeniedMessage 검증
         then(kafkaService).should().sendMessage(eq(KafkaTopic.ALARM), racingDeniedMessageCaptor.capture());
         RacingDeniedMessage capturedDeniedMessage = racingDeniedMessageCaptor.getValue();
@@ -381,60 +368,57 @@ public class RacingServiceTest {
     }
 
     @Test
-    @DisplayName("denyRacing: 레이싱이 대기 중이 아니면 예외 발생")
-    void denyRacing_WhenRacingNotWaiting_ShouldThrowException() {
+    void denyRacing_레이싱이대기중이아님_예외() {
         // Given
         given(racingRepository.existsByIdAndRaceStatusAndStatus(RACING_ID, WAIT, Status.ALIVE)).willReturn(false);
 
         // When & Then
-        ScheduleException exception = assertThrows(ScheduleException.class, 
+        ScheduleException exception = assertThrows(ScheduleException.class,
             () -> racingService.denyRacing(MEMBER_ID, SCHEDULE_ID, RACING_ID));
         assertThat(exception.getStatus()).isEqualTo(NO_SUCH_SCHEDULE);
     }
 
     @Test
-    @DisplayName("denyRacing: 사용자가 두 번째 레이서가 아니면 예외 발생")
-    void denyRacing_WhenMemberIsNotSecondRacer_ShouldThrowException() {
+    void denyRacing_사용자가두번째레이서가아님_예외() {
         // Given
         given(racingRepository.existsByIdAndRaceStatusAndStatus(RACING_ID, WAIT, Status.ALIVE)).willReturn(true);
         given(racingRepository.checkMemberIsSecondRacerInRacing(MEMBER_ID, RACING_ID)).willReturn(false);
 
         // When & Then
-        RacingException exception = assertThrows(RacingException.class, 
+        RacingException exception = assertThrows(RacingException.class,
             () -> racingService.denyRacing(MEMBER_ID, SCHEDULE_ID, RACING_ID));
         assertThat(exception.getStatus()).isEqualTo(NOT_IN_RACING);
     }
 
     @Test
-    @DisplayName("makeMemberWinnerInRacing: 사용자를 레이싱 우승자로 설정 성공")
-    void makeMemberWinnerInRacing_ShouldMakeMemberWinner() {
+    void makeMemberWinnerInRacing_정상() {
         // Given
         AlarmMemberInfo memberInfo = mock(AlarmMemberInfo.class);
         AlarmMemberInfo targetMemberInfo = mock(AlarmMemberInfo.class);
-        
+
         given(scheduleRepository.findScheduleMemberIdByMemberAndScheduleId(MEMBER_ID, SCHEDULE_ID))
             .willReturn(Optional.of(SCHEDULE_MEMBER_ID));
-        
+
         RunningRacingDto racingDto = new RunningRacingDto(
             RACING_ID, SCHEDULE_MEMBER_ID, TARGET_SCHEDULE_MEMBER_ID, POINT_AMOUNT
         );
         given(racingRepository.findRunningRacingsByScheduleMemberId(SCHEDULE_MEMBER_ID))
             .willReturn(Collections.singletonList(racingDto));
-        
+
         given(memberRepository.findMemberInfoByScheduleMemberId(SCHEDULE_MEMBER_ID))
             .willReturn(Optional.of(memberInfo));
         given(memberRepository.findMemberInfoByScheduleMemberId(TARGET_SCHEDULE_MEMBER_ID))
             .willReturn(Optional.of(targetMemberInfo));
-        
+
         given(racingRepository.findRacersFcmTokensInRacing(RACING_ID))
             .willReturn(Arrays.asList(MEMBER_FCM_TOKEN, TARGET_MEMBER_FCM_TOKEN));
-        
+
         // When
         racingService.makeMemberWinnerInRacing(MEMBER_ID, SCHEDULE_ID, SCHEDULE_NAME);
-        
+
         // Then
         then(racingRepository).should().setWinnerAndTermRacingByScheduleMemberId(SCHEDULE_MEMBER_ID);
-        
+
         // PointChangedMessage 검증
         then(kafkaService).should().sendMessage(eq(KafkaTopic.ALARM), pointChangedMessageCaptor.capture());
         PointChangedMessage capturedPointMessage = pointChangedMessageCaptor.getValue();
@@ -443,7 +427,7 @@ public class RacingServiceTest {
         assertThat(capturedPointMessage.getPointAmount()).isEqualTo(POINT_AMOUNT * 2);
         assertThat(capturedPointMessage.getReason()).isEqualTo(PointChangeReason.RACING_REWARD);
         assertThat(capturedPointMessage.getReasonId()).isEqualTo(RACING_ID);
-        
+
         // RacingTermMessage 검증
         then(kafkaService).should().sendMessage(eq(KafkaTopic.ALARM), racingTermMessageCaptor.capture());
         RacingTermMessage capturedTermMessage = racingTermMessageCaptor.getValue();
@@ -458,40 +442,39 @@ public class RacingServiceTest {
     }
 
     @Test
-    @DisplayName("terminateRunningRacing: 모든 진행 중인 레이싱 종료 처리")
-    void terminateRunningRacing_ShouldTerminateAllRunningRacings() {
+    void terminateRunningRacing_정상() {
         // Given
         AlarmMemberInfo memberInfo = mock(AlarmMemberInfo.class);
         AlarmMemberInfo targetMemberInfo = mock(AlarmMemberInfo.class);
-        
+
         TermRacingDto racingDto = new TermRacingDto(
             RACING_ID, SCHEDULE_MEMBER_ID, TARGET_SCHEDULE_MEMBER_ID, POINT_AMOUNT
         );
         given(racingRepository.findTermRacingIdsWithNoWinnerInSchedule(SCHEDULE_ID))
             .willReturn(Collections.singletonList(racingDto));
-        
+
         given(memberRepository.findMemberInfoByScheduleMemberId(SCHEDULE_MEMBER_ID))
             .willReturn(Optional.of(memberInfo));
         given(memberRepository.findMemberInfoByScheduleMemberId(TARGET_SCHEDULE_MEMBER_ID))
             .willReturn(Optional.of(targetMemberInfo));
-        
+
         // When
         racingService.terminateRunningRacing(SCHEDULE_ID);
-        
+
         // Then
         then(racingRepository).should().terminateRunningRacing(SCHEDULE_ID);
-        
+
         // PointChangedMessage 검증 (2개 메시지)
         then(kafkaService).should(times(2)).sendMessage(eq(KafkaTopic.ALARM), pointChangedMessageCaptor.capture());
         List<PointChangedMessage> pointChangedMessages = pointChangedMessageCaptor.getAllValues();
-        
+
         // 첫 번째 메시지 검증
         assertThat(pointChangedMessages.get(0).getMemberId()).isEqualTo(memberInfo.getMemberId());
         assertThat(pointChangedMessages.get(0).getPointChangedType()).isEqualTo(PointChangedType.PLUS);
         assertThat(pointChangedMessages.get(0).getPointAmount()).isEqualTo(POINT_AMOUNT);
         assertThat(pointChangedMessages.get(0).getReason()).isEqualTo(PointChangeReason.RACING_DRAW);
         assertThat(pointChangedMessages.get(0).getReasonId()).isEqualTo(RACING_ID);
-        
+
         // 두 번째 메시지 검증
         assertThat(pointChangedMessages.get(1).getMemberId()).isEqualTo(targetMemberInfo.getMemberId());
         assertThat(pointChangedMessages.get(1).getPointChangedType()).isEqualTo(PointChangedType.PLUS);

--- a/aiku/aiku-map/src/test/java/map/service/racing/RacingServiceTest.java
+++ b/aiku/aiku-map/src/test/java/map/service/racing/RacingServiceTest.java
@@ -1,0 +1,4 @@
+package map.service.racing;
+
+public class RacingServiceTest {
+}

--- a/aiku/aiku-map/src/test/java/map/service/unit_test/MapServiceUnitTest.java
+++ b/aiku/aiku-map/src/test/java/map/service/unit_test/MapServiceUnitTest.java
@@ -1,0 +1,299 @@
+package map.service.unit_test;
+
+import common.domain.Arrival;
+import common.domain.Location;
+import common.domain.Status;
+import common.domain.schedule.Schedule;
+import common.domain.schedule.ScheduleMember;
+import common.kafka_message.KafkaTopic;
+import common.kafka_message.ScheduleCloseMessage;
+import common.kafka_message.alarm.*;
+import map.application_event.event.MemberArrivalEvent;
+import map.application_event.event.ScheduleCloseEvent;
+import map.dto.*;
+import map.exception.MemberNotFoundException;
+import map.exception.ScheduleException;
+import map.kafka.KafkaProducerService;
+import map.repository.arrival.ArrivalRepository;
+import map.repository.member.MemberRepository;
+import map.repository.schedule.ScheduleRepository;
+import map.repository.schedule_location.ScheduleLocationRepository;
+import map.service.MapService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.springframework.context.ApplicationEventPublisher;
+
+import java.time.LocalDateTime;
+import java.util.*;
+
+import static common.domain.ExecStatus.RUN;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.mockito.BDDMockito.given;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class MapServiceUnitTest {
+
+    @Mock KafkaProducerService kafkaService;
+    @Mock MemberRepository memberRepository;
+    @Mock ScheduleRepository scheduleRepository;
+    @Mock ScheduleLocationRepository scheduleLocationRepository;
+    @Mock ArrivalRepository arrivalRepository;
+    @Mock ApplicationEventPublisher publisher;
+
+    @InjectMocks MapService mapService;
+
+    Long memberId = 1L;
+    Long scheduleId = 10L;
+    String scheduleName = "testSchedule";
+    LocalDateTime now = LocalDateTime.now();
+
+    @Test
+    void getScheduleDetail_정상() {
+        Location location = new Location("Test Location", 1.0, 2.0);
+        Schedule schedule = mock(Schedule.class);
+        given(schedule.getLocation()).willReturn(location);
+
+        List<ScheduleMemberResDto> members = List.of(mock(ScheduleMemberResDto.class));
+        given(scheduleRepository.findById(scheduleId)).willReturn(Optional.of(schedule));
+        given(scheduleRepository.existMemberInSchedule(memberId, scheduleId)).willReturn(true);
+        given(scheduleRepository.getScheduleMembersInfo(scheduleId)).willReturn(members);
+
+        ScheduleDetailResDto res = mapService.getScheduleDetail(memberId, scheduleId);
+
+        assertThat(res).isNotNull();
+        assertThat(res.getScheduleId()).isEqualTo(schedule.getId());
+        assertThat(res.getMembers()).isEqualTo(members);
+    }
+
+    @Test
+    void getScheduleDetail_스케줄없음_예외() {
+        given(scheduleRepository.findById(scheduleId)).willReturn(Optional.empty());
+
+        assertThrows(ScheduleException.class, () -> mapService.getScheduleDetail(memberId, scheduleId));
+    }
+
+    @Test
+    void getScheduleDetail_멤버없음_예외() {
+        given(scheduleRepository.findById(scheduleId)).willReturn(Optional.of(mock(Schedule.class)));
+        given(scheduleRepository.existMemberInSchedule(memberId, scheduleId)).willReturn(false);
+
+        assertThrows(ScheduleException.class, () -> mapService.getScheduleDetail(memberId, scheduleId));
+    }
+
+    @Test
+    void saveAndSendAllLocation_정상() {
+        RealTimeLocationDto dto = new RealTimeLocationDto(1.0, 2.0);
+        List<RealTimeLocationResDto> locs = List.of(mock(RealTimeLocationResDto.class));
+        given(scheduleRepository.existMemberInSchedule(memberId, scheduleId)).willReturn(true);
+        given(scheduleLocationRepository.getScheduleLocations(scheduleId)).willReturn(locs);
+
+        LocationsResponseDto res = mapService.saveAndSendAllLocation(memberId, scheduleId, dto);
+
+        assertThat(res.getCount()).isEqualTo(locs.size());
+        assertThat(res.getLocations()).isEqualTo(locs);
+        verify(scheduleLocationRepository).saveLocation(scheduleId, memberId, 1.0, 2.0);
+    }
+
+    @Test
+    void saveAndSendAllLocation_멤버없음_예외() {
+        given(scheduleRepository.existMemberInSchedule(memberId, scheduleId)).willReturn(false);
+
+        assertThrows(ScheduleException.class, () -> mapService.saveAndSendAllLocation(memberId, scheduleId, new RealTimeLocationDto(1.0,2.0)));
+    }
+
+    @Test
+    void getAllLocation_정상() {
+        List<RealTimeLocationResDto> locs = List.of(mock(RealTimeLocationResDto.class));
+        given(scheduleRepository.existMemberInSchedule(memberId, scheduleId)).willReturn(true);
+        given(scheduleLocationRepository.getScheduleLocations(scheduleId)).willReturn(locs);
+
+        LocationsResponseDto res = mapService.getAllLocation(memberId, scheduleId);
+
+        assertThat(res.getCount()).isEqualTo(locs.size());
+        assertThat(res.getLocations()).isEqualTo(locs);
+    }
+
+    @Test
+    void getAllLocation_멤버없음_예외() {
+        given(scheduleRepository.existMemberInSchedule(memberId, scheduleId)).willReturn(false);
+
+        assertThrows(ScheduleException.class, () -> mapService.getAllLocation(memberId, scheduleId));
+    }
+
+    @Test
+    void makeMemberArrive_마지막멤버_정상() {
+        Schedule schedule = mock(Schedule.class);
+        ScheduleMember scheduleMember = mock(ScheduleMember.class);
+        Location location = new Location("Location1",1.0, 2.0);
+        given(scheduleRepository.existMemberInSchedule(memberId, scheduleId)).willReturn(true);
+        given(scheduleRepository.existsByIdAndScheduleStatusAndStatus(scheduleId, RUN, Status.ALIVE)).willReturn(true);
+        given(scheduleRepository.findById(scheduleId)).willReturn(Optional.of(schedule));
+        given(scheduleRepository.findScheduleMember(memberId, scheduleId)).willReturn(Optional.of(scheduleMember));
+        given(schedule.getLocation()).willReturn(location);
+        given(schedule.getScheduleName()).willReturn(scheduleName);
+        given(arrivalRepository.isAllMembersInScheduleArrived(scheduleId)).willReturn(true);
+
+        MemberArrivalDto dto = new MemberArrivalDto(now);
+        Long res = mapService.makeMemberArrive(memberId, scheduleId, dto);
+
+        assertThat(res).isEqualTo(scheduleId);
+        verify(arrivalRepository).save(any(Arrival.class));
+        verify(scheduleLocationRepository).saveLocation(scheduleId, memberId, 1.0, 2.0);
+        verify(scheduleLocationRepository).updateArrivalStatus(scheduleId, memberId, true);
+        verify(publisher).publishEvent(any(MemberArrivalEvent.class));
+        verify(publisher).publishEvent(any(ScheduleCloseEvent.class));
+    }
+
+    @Test
+    void makeMemberArrive_마지막아닌멤버_정상() {
+        Schedule schedule = mock(Schedule.class);
+        ScheduleMember scheduleMember = mock(ScheduleMember.class);
+        Location location = new Location("Location1", 1.0, 2.0);
+        given(scheduleRepository.existMemberInSchedule(memberId, scheduleId)).willReturn(true);
+        given(scheduleRepository.existsByIdAndScheduleStatusAndStatus(scheduleId, RUN, Status.ALIVE)).willReturn(true);
+        given(scheduleRepository.findById(scheduleId)).willReturn(Optional.of(schedule));
+        given(scheduleRepository.findScheduleMember(memberId, scheduleId)).willReturn(Optional.of(scheduleMember));
+        given(schedule.getLocation()).willReturn(location);
+        given(schedule.getScheduleName()).willReturn(scheduleName);
+        given(arrivalRepository.isAllMembersInScheduleArrived(scheduleId)).willReturn(false);
+
+        MemberArrivalDto dto = new MemberArrivalDto(now);
+        Long res = mapService.makeMemberArrive(memberId, scheduleId, dto);
+
+        assertThat(res).isEqualTo(scheduleId);
+        verify(arrivalRepository).save(any(Arrival.class));
+        verify(scheduleLocationRepository).saveLocation(scheduleId, memberId, 1.0, 2.0);
+        verify(scheduleLocationRepository).updateArrivalStatus(scheduleId, memberId, true);
+        verify(publisher).publishEvent(any(MemberArrivalEvent.class));
+        verify(publisher, never()).publishEvent(isA(ScheduleCloseEvent.class));
+    }
+
+    @Test
+    void makeMemberArrive_멤버없음_예외() {
+        given(scheduleRepository.existMemberInSchedule(memberId, scheduleId)).willReturn(false);
+
+        assertThrows(ScheduleException.class, () -> mapService.makeMemberArrive(memberId, scheduleId, new MemberArrivalDto(now)));
+    }
+
+    @Test
+    void makeMemberArrive_스케줄상태_예외() {
+        given(scheduleRepository.existMemberInSchedule(memberId, scheduleId)).willReturn(true);
+        given(scheduleRepository.existsByIdAndScheduleStatusAndStatus(scheduleId, RUN, Status.ALIVE)).willReturn(false);
+
+        assertThrows(ScheduleException.class, () -> mapService.makeMemberArrive(memberId, scheduleId, new MemberArrivalDto(now)));
+    }
+
+    @Test
+    void sendEmoji_정상() {
+        EmojiDto emojiDto = new EmojiDto(2L, EmojiType.HEART);
+        AlarmMemberInfo sender = mock(AlarmMemberInfo.class);
+        AlarmMemberInfo receiver = mock(AlarmMemberInfo.class);
+        Schedule schedule = mock(Schedule.class);
+        given(scheduleRepository.existMemberInSchedule(memberId, scheduleId)).willReturn(true);
+        given(scheduleRepository.existsByIdAndScheduleStatusAndStatus(scheduleId, RUN, Status.ALIVE)).willReturn(true);
+        given(memberRepository.findMemberInfo(memberId)).willReturn(Optional.of(sender));
+        given(memberRepository.findMemberInfo(2L)).willReturn(Optional.of(receiver));
+        given(memberRepository.findMemberFirebaseTokenById(2L)).willReturn(Optional.of("token"));
+        given(scheduleRepository.findById(scheduleId)).willReturn(Optional.of(schedule));
+        given(schedule.getScheduleName()).willReturn(scheduleName);
+
+        Long res = mapService.sendEmoji(memberId, scheduleId, emojiDto);
+
+        assertThat(res).isEqualTo(scheduleId);
+        verify(kafkaService).sendMessage(eq(KafkaTopic.ALARM), any(EmojiMessage.class));
+    }
+
+    @Test
+    void sendEmoji_멤버없음_예외() {
+        EmojiDto emojiDto = new EmojiDto(2L, EmojiType.HEART);
+        given(scheduleRepository.existMemberInSchedule(memberId, scheduleId)).willReturn(false);
+
+        assertThrows(ScheduleException.class, () -> mapService.sendEmoji(memberId, scheduleId, emojiDto));
+    }
+
+    @Test
+    void sendEmoji_스케줄상태_예외() {
+        EmojiDto emojiDto = new EmojiDto(2L, EmojiType.HEART);
+        given(scheduleRepository.existMemberInSchedule(memberId, scheduleId)).willReturn(true);
+        given(scheduleRepository.existsByIdAndScheduleStatusAndStatus(scheduleId, RUN, Status.ALIVE)).willReturn(false);
+
+        assertThrows(ScheduleException.class, () -> mapService.sendEmoji(memberId, scheduleId, emojiDto));
+    }
+
+    @Test
+    void deleteAllLocationsInSchedule_정상() {
+        mapService.deleteAllLocationsInSchedule(scheduleId);
+
+        verify(scheduleLocationRepository).deleteScheduleLocations(scheduleId);
+    }
+
+    @Test
+    void makeNotArrivedMemberArrive_정상() {
+        ScheduleMember sm1 = mock(ScheduleMember.class);
+        ScheduleMember sm2 = mock(ScheduleMember.class);
+        List<ScheduleMember> notArrived = List.of(sm1, sm2);
+        given(scheduleRepository.findScheduleMembersNotInArrivalByScheduleId(scheduleId)).willReturn(notArrived);
+
+        mapService.makeNotArrivedMemberArrive(scheduleId, now);
+        verify(arrivalRepository).saveAll(anyList());
+    }
+
+    @Test
+    void sendKafkaAlarmIfMemberArrived_정상() {
+        List<String> tokens = List.of("token1", "token2");
+        AlarmMemberInfo info = mock(AlarmMemberInfo.class);
+        given(scheduleRepository.findAllFcmTokensInSchedule(scheduleId)).willReturn(tokens);
+        given(memberRepository.findMemberInfo(memberId)).willReturn(Optional.of(info));
+
+        mapService.sendKafkaAlarmIfMemberArrived(memberId, scheduleId, scheduleName, now);
+
+        verify(kafkaService).sendMessage(eq(KafkaTopic.ALARM), any(ArrivalAlarmMessage.class));
+    }
+
+    @Test
+    void sendKafkaEventIfScheduleClosed_정상() {
+        mapService.sendKafkaEventIfScheduleClosed(scheduleId, now);
+
+        verify(kafkaService).sendMessage(eq(KafkaTopic.SCHEDULE_CLOSE), any(ScheduleCloseMessage.class));
+    }
+
+    @Test
+    void findSchedule_없으면_예외() {
+        given(scheduleRepository.findById(scheduleId)).willReturn(Optional.empty());
+
+        assertThrows(ScheduleException.class, () -> {
+            // private 메서드 테스트를 위해 public 메서드를 호출
+            mapService.getScheduleDetail(memberId, scheduleId);
+        });
+    }
+
+    @Test
+    void findScheduleMember_없으면_예외() {
+        given(scheduleRepository.existMemberInSchedule(memberId, scheduleId)).willReturn(true);
+        given(scheduleRepository.existsByIdAndScheduleStatusAndStatus(scheduleId, RUN, Status.ALIVE)).willReturn(true);
+        given(scheduleRepository.findById(scheduleId)).willReturn(Optional.of(mock(Schedule.class)));
+        given(scheduleRepository.findScheduleMember(memberId, scheduleId)).willReturn(Optional.empty());
+
+        assertThrows(ScheduleException.class, () -> mapService.makeMemberArrive(memberId, scheduleId, new MemberArrivalDto(now)));
+    }
+
+    @Test
+    void checkMemberInSchedule_없으면_예외() {
+        given(scheduleRepository.existMemberInSchedule(memberId, scheduleId)).willReturn(false);
+
+        assertThrows(ScheduleException.class, () -> mapService.getAllLocation(memberId, scheduleId));
+    }
+
+    @Test
+    void checkScheduleInRun_없으면_예외() {
+        given(scheduleRepository.existMemberInSchedule(memberId, scheduleId)).willReturn(true);
+        given(scheduleRepository.existsByIdAndScheduleStatusAndStatus(scheduleId, RUN, Status.ALIVE)).willReturn(false);
+
+        assertThrows(ScheduleException.class, () -> mapService.makeMemberArrive(memberId, scheduleId, new MemberArrivalDto(now)));
+    }
+}


### PR DESCRIPTION
## 관련 이슈 번호
<br />

- #210 

## 작업 사항
<br />

- MapService에 대한 단위 테스트 작성
- RacingService에 대한 단위 테스트 작성
- 테스트 패키지 구조를 도메인 단위로 세분화

## 기타 사항
<br />

- `@Captor` 어노테이션을 이용해 ArgumentCaptor를 전역 변수로 선언하였습니다. 선언부 반복을 단순화하여 중복을 줄일 수 있었습니다.